### PR TITLE
Specify paper remaining for desktop notifications

### DIFF
--- a/printing/paper
+++ b/printing/paper
@@ -90,6 +90,7 @@ $balanced = ceil($balanced);
 
 }
 
-print "Printing quota remaining\n";
-print "Semester: $balance pages\n";
-print "Today: $balanced pages\n";
+print "Printing quota:\n";
+print "Semester: $balance pages remaining\n";
+print "Today: $balanced pages remaining\n";
+


### PR DESCRIPTION
I overheard some people in the lab today who were confused about the print counts listed in the notification. This should make the desktop notifications more specific that the paper counts listed are remaining amounts, not how many pages the user has already printed in the current day or semester.