### PR TITLE
Add volume control to ocf-tv

### DIFF
--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -44,7 +44,7 @@ def volume(args):
 def volume_in_range(val):
     x = int(val)
     if x < 0 or x > 130:
-        raise argparse.ArgumentTypeError("{} is not within the range (0, 130)".format(val))
+        raise argparse.ArgumentTypeError("{} is not within the range (0, 150)".format(val))
     return val
         
 def connect(args):

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import sys
 import argparse
 import random
 import socket
@@ -37,7 +38,15 @@ def wait_for_port(host, port, timeout=5):
         if spent > timeout:
             raise TimeoutError('Timed out after {} seconds.'.format(timeout))
 
+def volume(args):
+    call(('ssh', args.host, "export PULSE_SERVER=localhost; pactl set-sink-volume {} {}%".format(args.sink, args.amount)))
 
+def volume_in_range(val):
+    x = int(val)
+    if x < 0 or x > 130:
+        raise argparse.ArgumentTypeError("{} is not within the range (0, 130)".format(val))
+    return val
+        
 def connect(args):
     port = unused_port()
     proc = Popen(('ssh', '-L', '{}:localhost:5900'.format(port), '-N', args.host))
@@ -50,13 +59,26 @@ def connect(args):
 if __name__ == '__main__':
     commands = {
         'connect': connect,
+        'volume': volume
     }
     parser = argparse.ArgumentParser(
         description='Control the OCF television.',
     )
     parser.add_argument('-H', '--host', type=str, default='tv')
-    parser.add_argument('command', type=str, nargs='?',
-                        choices=commands.keys(), default='connect')
 
-    args = parser.parse_args()
+    command_subparser = parser.add_subparsers(dest='command', help='command to run')
+
+    subparser_connect = command_subparser.add_parser('connect', help='open a vnc instance to view the TV screen')
+    #subparser_connect.add_argument('command', type=str, nargs='?', choices=commands.keys(), default='connect')
+
+    subparser_volume = command_subparser.add_parser('volume', help='set the volume for a PulseAudio sink on the TV')
+    subparser_volume.add_argument('--sink', '-s', required=False, type=str, default='0')
+    subparser_volume.add_argument('amount', type=volume_in_range, default='100', help='volume in percent between 0 and 130')
+
+    if len(sys.argv) == 1:
+        args = parser.parse_args(['connect'])
+    else:
+        args = parser.parse_args() # default is sys.argv
+    
+    # args = parser.parse_args()
     commands[args.command](args)

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -53,11 +53,13 @@ def volume_in_range(val):
 
 def connect(args):
     port = unused_port()
-    proc = Popen(('ssh', '-L', '{}:localhost:5900'.format(port), '-N', args.host))
+    proc = Popen(['ssh', '-N', '-o', 'ExitOnForwardFailure=yes',
+                  '-L', '{}:localhost:5900'.format(port), args.host])
     wait_for_port('localhost', port)
-    call(('xvnc4viewer', 'localhost:{}'.format(port)))
+    call(['xvnc4viewer', 'localhost:{}'.format(port)])
     proc.terminate()
     proc.wait()
+    call(['stty', 'echo'])
 
 
 if __name__ == '__main__':

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-import sys
 import argparse
 import random
 import socket
+import sys
 import time
 from subprocess import call
 from subprocess import Popen
@@ -38,22 +38,26 @@ def wait_for_port(host, port, timeout=5):
         if spent > timeout:
             raise TimeoutError('Timed out after {} seconds.'.format(timeout))
 
+
 def volume(args):
-    call(('ssh', args.host, "export PULSE_SERVER=localhost; pactl set-sink-volume {} {}%".format(args.sink, args.amount)))
+    call(('ssh', args.host,
+          'export PULSE_SERVER=localhost; pactl set-sink-volume {} {}%'.format(args.sink, args.amount)))
+
 
 def volume_in_range(val):
     x = int(val)
     if x < 0 or x > 130:
-        raise argparse.ArgumentTypeError("{} is not within the range (0, 150)".format(val))
+        raise argparse.ArgumentTypeError('{} is not within the range (0, 150)'.format(val))
     return val
-        
+
+
 def connect(args):
     port = unused_port()
     proc = Popen(('ssh', '-L', '{}:localhost:5900'.format(port), '-N', args.host))
     wait_for_port('localhost', port)
     call(('xvnc4viewer', 'localhost:{}'.format(port)))
     proc.terminate()
-    proc.wait()
+    proc.wgait()
 
 
 if __name__ == '__main__':
@@ -69,16 +73,15 @@ if __name__ == '__main__':
     command_subparser = parser.add_subparsers(dest='command', help='command to run')
 
     subparser_connect = command_subparser.add_parser('connect', help='open a vnc instance to view the TV screen')
-    #subparser_connect.add_argument('command', type=str, nargs='?', choices=commands.keys(), default='connect')
 
     subparser_volume = command_subparser.add_parser('volume', help='set the volume for a PulseAudio sink on the TV')
     subparser_volume.add_argument('--sink', '-s', required=False, type=str, default='0')
-    subparser_volume.add_argument('amount', type=volume_in_range, default='100', help='volume in percent between 0 and 130')
+    subparser_volume.add_argument('amount', type=volume_in_range,
+                                  default='100', help='volume in percent between 0 and 130')
 
     if len(sys.argv) == 1:
         args = parser.parse_args(['connect'])
     else:
-        args = parser.parse_args() # default is sys.argv
-    
-    # args = parser.parse_args()
+        args = parser.parse_args()  # default is sys.argv
+
     commands[args.command](args)

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -26,9 +26,12 @@ def unused_port():
     return port
 
 
-def wait_for_port(host, port, timeout=5):
+def wait_for_port(host, port, timeout=5, ssh_proc=None):
     spent = 0
     while True:
+        if ssh_proc and ssh_proc.poll():
+            raise ChildProcessError("SSH exited too quickly. Maybe run kinit?")
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             if s.connect_ex((host, port)) == 0:
                 return
@@ -54,12 +57,12 @@ def volume_in_range(val):
 def connect(args):
     port = unused_port()
     proc = Popen(['ssh', '-N', '-o', 'ExitOnForwardFailure=yes',
+                  '-o', 'BatchMode=yes',
                   '-L', '{}:localhost:5900'.format(port), args.host])
-    wait_for_port('localhost', port)
+    wait_for_port('localhost', port, ssh_proc=proc)
     call(['xvnc4viewer', 'localhost:{}'.format(port)])
     proc.terminate()
     proc.wait()
-    call(['stty', 'echo'])
 
 
 if __name__ == '__main__':

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -57,7 +57,7 @@ def connect(args):
     wait_for_port('localhost', port)
     call(('xvnc4viewer', 'localhost:{}'.format(port)))
     proc.terminate()
-    proc.wgait()
+    proc.wait()
 
 
 if __name__ == '__main__':

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -30,7 +30,7 @@ def wait_for_port(host, port, timeout=5, ssh_proc=None):
     spent = 0
     while True:
         if ssh_proc and ssh_proc.poll():
-            raise ChildProcessError("SSH exited too quickly. Maybe run kinit?")
+            raise ChildProcessError('SSH exited too quickly. Maybe run kinit?')
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             if s.connect_ex((host, port)) == 0:


### PR DESCRIPTION
Now you can do `$ ocf-tv volume (0, 150)` to change the volume of the TV from 0% to 150% of baseline. It seems to work pretty decently, occasionally asks for you for a password to tornado. `connect` is still the default. 

When it does ask for a password however, `connect` will timeout if you aren't able to type the pwd fast enough, and after that fails, the terminal begins to exhibit weird behavior - no newlines on enter, no characters shown when typing, although it stills reads the input and executes when you press enter. Need to spawn a new terminal to fix it. Can't really explain why that happens when login fails.