### PR TITLE
echo stty after ocf-tv connect

### DIFF
--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -40,11 +40,13 @@ def wait_for_port(host, port, timeout=5):
 
 def connect(args):
     port = unused_port()
-    proc = Popen(('ssh', '-L', '{}:localhost:5900'.format(port), '-N', args.host))
+    proc = Popen(['ssh', '-N', '-o', 'ExitOnForwardFailure=yes',
+                  '-L', '{}:localhost:5900'.format(port), args.host])
     wait_for_port('localhost', port)
-    call(('xvnc4viewer', 'localhost:{}'.format(port)))
+    call(['xvnc4viewer', 'localhost:{}'.format(port)])
     proc.terminate()
     proc.wait()
+    call(['stty', 'echo'])
 
 
 if __name__ == '__main__':

--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -25,9 +25,12 @@ def unused_port():
     return port
 
 
-def wait_for_port(host, port, timeout=5):
+def wait_for_port(host, port, timeout=5, ssh_proc=None):
     spent = 0
     while True:
+        if ssh_proc and ssh_proc.poll():
+            raise ChildProcessError("SSH exited too quickly. Maybe run kinit?")
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             if s.connect_ex((host, port)) == 0:
                 return
@@ -41,12 +44,12 @@ def wait_for_port(host, port, timeout=5):
 def connect(args):
     port = unused_port()
     proc = Popen(['ssh', '-N', '-o', 'ExitOnForwardFailure=yes',
+                  '-o', 'BatchMode=yes',
                   '-L', '{}:localhost:5900'.format(port), args.host])
-    wait_for_port('localhost', port)
+    wait_for_port('localhost', port, ssh_proc=proc)
     call(['xvnc4viewer', 'localhost:{}'.format(port)])
     proc.terminate()
     proc.wait()
-    call(['stty', 'echo'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If ssh is killed during a password prompt, terminal echo is
disabled and needs to be re-enabled. This should not happen
with cleanup after SIGTERM, but just in case, per #32.

Alternatively, we can disable ssh password prompts entirely
with `-o BatchMode=yes` and use Kerberos/GSSAPI.
Personally I prefer that approach to providing my password
to an ocf-tv script, but this is a simple change for now.