### PR TITLE
Terminate ssh on ocf-tv exception

### DIFF
--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -46,10 +46,12 @@ def connect(args):
     proc = Popen(['ssh', '-N', '-o', 'ExitOnForwardFailure=yes',
                   '-o', 'BatchMode=yes',
                   '-L', '{}:localhost:5900'.format(port), args.host])
-    wait_for_port('localhost', port, ssh_proc=proc)
-    call(['xvnc4viewer', 'localhost:{}'.format(port)])
-    proc.terminate()
-    proc.wait()
+    try:
+        wait_for_port('localhost', port, ssh_proc=proc)
+        call(['xvnc4viewer', 'localhost:{}'.format(port)])
+    finally:
+        proc.terminate()
+        proc.wait()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, when an exception was raised, we would never
send SIGTERM to ssh. ssh would continue to run, stuck in
the password prompt, despite the error traceback.