### PR TITLE
Add shellcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,5 +41,4 @@
         description: Check Shell Syntax on ALL staged files with user friendly messages and colors
         entry: shell-lint.sh
         language: script
-        exclude: ^.deactivate.sh$
         types: [executable, shell]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,15 @@
     hooks:
     -   id: remove-tabs
         language_version: python2.7
+# TODO: Replace this with the actual repo
+# (https://github.com/detailyang/pre-commit-shell)
+# once it supports types and not just files ending in shell extensions
+-   repo: local
+    hooks:
+    -   id: shell-lint
+        name: Shell Syntax Check
+        description: Check Shell Syntax on ALL staged files with user friendly messages and colors
+        entry: shell-lint.sh
+        language: script
+        exclude: ^.deactivate.sh$
+        types: [executable, shell]

--- a/acct/check
+++ b/acct/check
@@ -13,7 +13,7 @@ wtmp_files='/var/log/wtmp /var/log/wtmp.1'
 login_count=5
 
 usage(){
-  echo "Usage: $(basename $0) USER [login_count]"
+  echo "Usage: $(basename "$0") USER [login_count]"
   echo "USER is the username to look up, must be alphanumeric"
   echo "login_count is the number of logins to display, default is 5"
   echo
@@ -24,7 +24,7 @@ usage(){
 }
 
 # process arguments including basic sanitization and respond if needed
-if [ $# -gt 2 -o $# -eq 0 ]; then
+if [ $# -gt 2 ] || [ $# -eq 0 ]; then
   usage
   exit 1
 elif [ "$1" = '-h' ] || [ "$1" = '--help' ]; then
@@ -34,7 +34,7 @@ else
   user=$(echo "$1" | tr -cd '[:alnum:]')
   if [ -n "$2" ]; then
     login_count=$(echo "$2" | tr -cd '[:digit:]')
-    if [ -z $login_count ]; then
+    if [ -z "$login_count" ]; then
       echo 'Error: Invalid login_count' >&2
       echo
       usage
@@ -44,30 +44,30 @@ else
 fi
 
 # check user entry in passwd database
-getent=$(getent passwd $user)
+getent=$(getent passwd "$user")
 if [ -n "$getent" ]; then
   echo "$getent"
 else
-  echo $user not found >&2
+  echo "$user not found" >&2
   exit 2
 fi
 
 # check if sorried
-shell=$(ldapsearch -x -LLL uid=$user loginshell | grep ^loginShell | cut -d' ' -f2)
-if [ $shell = /opt/share/utils/bin/sorried ]; then
+shell=$(ldapsearch -x -LLL uid="$user" loginshell | grep ^loginShell | cut -d' ' -f2)
+if [ "$shell" = /opt/share/utils/bin/sorried ]; then
   echo "WARNING: Account is disabled" >&2
 fi
 
 # account creation time
-creation_time=$(ldapsearch -x -LLL uid=$user creationTime | grep ^creationTime | cut -d' ' -f2)
+creation_time=$(ldapsearch -x -LLL uid="$user" creationTime | grep ^creationTime | cut -d' ' -f2)
 if [ -n "$creation_time" ]; then
   echo "Created on: $(python3 -c "import dateutil.parser; print(dateutil.parser.parse('${creation_time}').strftime('%Y-%m-%d'))")"
 fi
 
 # check if Kerberos principal exists
-kerberos=$(echo TESTIFEXIST | kinit --password-file=STDIN $user 2>&1)
+kerberos=$(echo TESTIFEXIST | kinit --password-file=STDIN "$user" 2>&1)
 if [ -n "$kerberos" ]; then
-  if [ -n "$(echo "$kerberos" | grep unknown$)" ]; then
+  if echo "$kerberos" | grep -q unknown$; then
     echo "WARNING: Kerberos principal does not exist" >&2
   elif [ "$kerberos" != "kinit: Password incorrect" ]; then
     echo "$kerberos"
@@ -76,15 +76,15 @@ fi
 
 # if on NFS, check if home directory exists
 if mount | grep -qE '^[a-z]+://home\b'; then
-  letter=$(echo $user | cut -c1)
-  letter2=$(echo $user | cut -c1-2)
-  homedir=/home/$letter/$letter2/$user
-  if [ ! -d $homedir ]; then
+  letter=$(echo "$user" | cut -c1)
+  letter2=$(echo "$user" | cut -c1-2)
+  homedir="/home/$letter/$letter2/$user"
+  if [ ! -d "$homedir" ]; then
     echo "WARNING: Home directory does not exist" >&2
   else
     # if home directory exists, check if web directory exists
-    webdir=/services/http/users/$letter/$user
-    if [ ! -d $webdir ]; then
+    webdir="/services/http/users/$letter/$user"
+    if [ ! -d "$webdir" ]; then
       echo "WARNING: Web directory does not exist" >&2
       echo "  You can create web directory by running:"
       echo "    sudo mkdir $webdir"
@@ -94,13 +94,13 @@ if mount | grep -qE '^[a-z]+://home\b'; then
 fi
 
 # check if member of groups other than ocf
-groups=$(groups $user | cut -d " " -f3- | grep -v "^ocf$")
+groups=$(groups "$user" | cut -d " " -f3- | grep -v "^ocf$")
 if [ -n "$groups" ]; then
   echo "Member of group(s): $groups"
 fi
 
 # check if CalLink OID number exists in LDAP
-callinkOid=$(ldapsearch -x -LLL uid=$user callinkOid | grep -i ^callinkOid | cut -d' ' -f2)
+callinkOid=$(ldapsearch -x -LLL uid="$user" callinkOid | grep -i ^callinkOid | cut -d' ' -f2)
 if [ -n "$callinkOid" ]; then
   echo "CalLink OID number: $callinkOid"
   if [ "$callinkOid" != 0 ]; then
@@ -109,10 +109,10 @@ if [ -n "$callinkOid" ]; then
 fi
 
 # check if CalNet UID number exists in LDAP
-calnetuid=$(ldapsearch -x -LLL uid=$user calnetuid | grep -i ^calnetuid | cut -d' ' -f2)
+calnetuid=$(ldapsearch -x -LLL uid="$user" calnetuid | grep -i ^calnetuid | cut -d' ' -f2)
 if [ -n "$calnetuid" ]; then
-  calnetemail=$(ldapsearch -x -LLL -H ldap://nds.berkeley.edu -b dc=berkeley,dc=edu uid=$calnetuid  mail | grep ^mail | cut -d' ' -f2)
-  calnetaffiliations=$(ldapsearch -x -LLL -H ldap://nds.berkeley.edu -b dc=berkeley,dc=edu uid=$calnetuid berkeleyEduAffiliations | grep ^berkeleyEduAffiliations | cut -d' ' -f2- | sed -r 's/(^|$)/\"/g' | sort | tr '\n' ' ' | sed 's/ $//g')
+  calnetemail=$(ldapsearch -x -LLL -H ldap://nds.berkeley.edu -b dc=berkeley,dc=edu uid="$calnetuid" mail | grep ^mail | cut -d' ' -f2)
+  calnetaffiliations=$(ldapsearch -x -LLL -H ldap://nds.berkeley.edu -b dc=berkeley,dc=edu uid="$calnetuid" berkeleyEduAffiliations | grep ^berkeleyEduAffiliations | cut -d' ' -f2- | sed -r 's/(^|$)/\"/g' | sort | tr '\n' ' ' | sed 's/ $//g')
   echo "CalNet UID number: $calnetuid"
   if [ -n "$calnetemail" ]; then
     echo "CalNet email address: $calnetemail"
@@ -145,7 +145,7 @@ echo
 paper view "$user"
 
 # check User_Info entries
-User_Info=$([ -f "$User_Info_file" ] && grep ^$user: "$User_Info_file" | cut -d: -f2-)
+User_Info=$([ -f "$User_Info_file" ] && grep ^"$user": "$User_Info_file" | cut -d: -f2-)
 if [ -n "$User_Info" ]; then
   echo
   echo "User_Info entr(y|ies):"
@@ -155,13 +155,13 @@ if [ -n "$User_Info" ]; then
 fi
 
 # list signatories for group account
-echo 
+echo
 echo "Signatories/Signatory for:"
-signat user $user
-    
+signat user "$user"
+
 
 # check user crontab, probably requires root privileges
-crontab=$(crontab -lu $user 2> /dev/null | sed '/^[ ]*$/d')
+crontab=$(crontab -lu "$user" 2> /dev/null | sed '/^[ ]*$/d')
 if [ -n "$crontab" ]; then
   echo
   echo "Crontab on local machine:"
@@ -172,8 +172,8 @@ fi
 
 
 # check currently running processes in tree format
-ps=$(ps Sfw -u $user 2> /dev/null | grep -Fv "PID TTY")
-fingerl=$(finger -m $user | grep "^On since")
+ps=$(ps Sfw -u "$user" 2> /dev/null | tail -n +2)
+fingerl=$(finger -m "$user" | grep "^On since")
 if [ -n "$fingerl" ] || [ -n "$ps" ]; then
   echo
   echo "Currently running processes on local machine:"
@@ -188,7 +188,7 @@ if [ -n "$fingerl" ] || [ -n "$ps" ]; then
 fi
 
 # check most recent login history
-last=$( (for wtmp_file in $wtmp_files; do last -a $user -f $wtmp_file; done) | egrep -v ' begins|^$' | head -n $login_count | awk '{$1=""; print $0}' | sed 's/^[ ]*//g')
+last=$( (for wtmp_file in $wtmp_files; do last -a "$user" -f "$wtmp_file"; done) | egrep -v ' begins|^$' | head -n "$login_count" | awk '{$1=""; print $0}' | sed 's/^[ ]*//g')
 if [ -n "$last" ]; then
   echo
   echo "Recent login history on local machine:"

--- a/acct/check
+++ b/acct/check
@@ -145,7 +145,7 @@ echo
 paper view "$user"
 
 # check User_Info entries
-User_Info=$([ -f "$User_Info_file" ] && grep ^"$user": "$User_Info_file" | cut -d: -f2-)
+User_Info=$([ -f "$User_Info_file" ] && grep "^$user": "$User_Info_file" | cut -d: -f2-)
 if [ -n "$User_Info" ]; then
   echo
   echo "User_Info entr(y|ies):"

--- a/acct/checkacct
+++ b/acct/checkacct
@@ -11,6 +11,7 @@ while [ $# -ne 0 ]; do
     SEARCHQUERY="$SEARCHQUERY (|(uid=*$1*)(cn=*$1*))"
     shift
 done
-for username in `ldapsearch -LLL -x "(&$SEARCHQUERY)" uid | grep '^uid' | cut -f2 -d' '`; do
-    finger -m $username | head -1
+
+for username in $(ldapsearch -LLL -x "(&$SEARCHQUERY)" uid | grep '^uid' | cut -f2 -d' '); do
+    finger -m "$username" | head -1
 done

--- a/desktop/pdf-open
+++ b/desktop/pdf-open
@@ -1,10 +1,10 @@
 #!/bin/bash -e
-[ "$#" -ne 1 ] && (echo 'Bad arguments, trying evince...'; exec evince $@)
-[ -f "$1" ] || (echo 'File does not exist, trying evince...'; exec evince $@)
+[ "$#" -ne 1 ] && (echo 'Bad arguments, trying evince...'; exec evince "$@")
+[ -f "$1" ] || (echo 'File does not exist, trying evince...'; exec evince "$@")
 
-size=$(du "$1") || (echo 'Cannot get size, trying evince...'; exec evince $@)
+size=$(du "$1") || (echo 'Cannot get size, trying evince...'; exec evince "$@")
 size=$(cut -f1 <<< "$size")
-[ "$size" -lt 5120 ] || (echo 'Too large, trying evince...'; exec evince $@)
+[ "$size" -lt 5120 ] || (echo 'Too large, trying evince...'; exec evince "$@")
 
 echo 'Rasterizing PDF...'
 tmp=$(mktemp --suffix='.pdf')
@@ -12,7 +12,7 @@ tmp=$(mktemp --suffix='.pdf')
 if ! convert -density 250 "$1" "$tmp"; then
     rm "$tmp"
     echo 'Convert failed, trying evince...'
-    exec evince $@
+    exec evince "$@"
 fi
 
 echo 'Done rasterizing, now opening with evince...'

--- a/shell-lint.sh
+++ b/shell-lint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+which shellcheck &> /dev/null
+if [[ $? != 0 ]]; then
+    echo "are you sure you have installed shellcheck?"
+    exit 1
+fi
+
+shellcheck "$@"
+exit $?

--- a/staff/acct/sorry/sorry
+++ b/staff/acct/sorry/sorry
@@ -1,48 +1,46 @@
 #!/bin/bash
 # Script for sorrying OCF user accounts
 
-LDAPSEARCH=`which ldapsearch`
-LDAPMODIFY=`which ldapmodify`
-KINIT=`which kinit`
-KDESTROY=`which kdestroy`
+LDAPSEARCH=$(which ldapsearch)
+LDAPMODIFY=$(which ldapmodify)
+KINIT=$(which kinit)
+KDESTROY=$(which kdestroy)
 #KRB5CCNAME=/root/krb5cc_sorry
 #export KRB5CCNAME
 
-#check to see if running as root
-if [ `/usr/bin/id -u` != 0 ]
-then echo "You must be root to run this."
-exit 2
+# check to see if running as root
+if [ "$(/usr/bin/id -u)" != 0 ]; then
+    echo "You must be root to run this."
+    exit 2
 fi
 
-if [ x$1 = x -o x$2 = x ]; then
-echo "Usage: $0 [user to be sorried] [sorry reason file]"
-exit 0
+if [ x"$1" = x ] || [ x"$2" = x ]; then
+    echo "Usage: $0 [user to be sorried] [sorry reason file]"
+    exit 0
 fi
 
 sorriedUser=$1
 
-if [ -z "`getent passwd $sorriedUser`" ]; then
-  echo "User $sorriedUser does not exist"
-  exit 3
+if [ -z "$(getent passwd "$sorriedUser")" ]; then
+    echo "User $sorriedUser does not exist"
+    exit 3
 fi
 
 sorryFile=$2
-userdir=`ldapsearch -x uid=$sorriedUser | grep homeDirectory | cut -d' ' -f2`
-
-httpdir=`echo $sorriedUser | sed -e 's%\(\(.\)\)%/services/http/users/\2/\1%'`
+userdir=$(ldapsearch -x uid="$sorriedUser" | grep homeDirectory | cut -d' ' -f2)
+httpdir="${sorriedUser//\(\(.\)\)/\/services\/http\/users\/\2/\1}"
 
 rootstaffer="$SUDO_USER"
 
-if [ x"$rootstaffer" = x"root" -o -z $rootstaffer ]
-then
+if [ x"$rootstaffer" = x"root" ] || [ -z "$rootstaffer" ]; then
     echo "The sorry.log is much more useful when it logs who you are"
     echo "rather than simply 'root'. Please enter your username:"
-    read rootstaffer
+    read -r rootstaffer
 fi
 
-if [ -z $SORRY_KRB5CCNAME ]; then
-    echo You are $rootstaffer
-    $KINIT ${rootstaffer}/admin
+if [ -z "$SORRY_KRB5CCNAME" ]; then
+    echo "You are $rootstaffer"
+    $KINIT "${rootstaffer}/admin"
     if [ $? -ne 0 ]; then
         echo "kinit failed, bailing out!"
         exit 1
@@ -50,7 +48,7 @@ if [ -z $SORRY_KRB5CCNAME ]; then
 else
     echo "SORRY_KRB5CCNAME set in environment."
     echo "Assuming this file contains current admin credentials."
-    KRB5CCNAME=$SORRY_KRB5CCNAME
+    KRB5CCNAME="$SORRY_KRB5CCNAME"
     export KRB5CCNAME
 fi
 
@@ -59,15 +57,15 @@ sorryshell=/opt/share/utils/bin/sorried
 echo ""
 echo "Copying sorry file and making .oldshell file"
 
-oldshell=`$LDAPSEARCH -x "(uid=$sorriedUser)" loginShell | grep "^loginShell:" | cut -d" " -f2`
+oldshell=$($LDAPSEARCH -x "(uid=$sorriedUser)" loginShell | grep "^loginShell:" | cut -d" " -f2)
 
-if [[ ! -f .oldshell ]]
-then
-echo $oldshell > $userdir/.oldshell
+if [[ ! -f .oldshell ]]; then
+    echo "$oldshell" > "$userdir/.oldshell"
 fi
-cp $sorryFile $userdir/.sorry
-chmod 400 $userdir/.sorry
-chown $sorriedUser:ocf $userdir/.sorry
+
+cp "$sorryFile" "$userdir/.sorry"
+chmod 400 "$userdir/.sorry"
+chown "$sorriedUser:ocf" "$userdir/.sorry"
 
 echo ""
 echo "Changing user's shell to a sorry shell"
@@ -83,26 +81,26 @@ gidNumber: 2390
 EOF
 
 echo "Changing permissions on httpdir to 000"
-if [[ -d $httpdir ]]
-then chmod 000 $httpdir
+if [[ -d "$httpdir" ]]; then
+    chmod 000 "$httpdir"
 fi
 
 echo ""
 echo "Changing permissions on home directory to 500"
-chmod 500 $userdir
+chmod 500 "$userdir"
 
 echo ""
 echo ""
 echo ""
 echo "Final system check"
-ldapsearch -x uid=$sorriedUser
+ldapsearch -x uid="$sorriedUser"
 ldapsearch -x cn=sorry | tail
-finger -m $sorriedUser
-ls -la $userdir
-ls -ld $httpdir
+finger -m "$sorriedUser"
+ls -la "$userdir"
+ls -ld "$httpdir"
 
-#logging
-echo `/bin/date` - $rootstaffer $sorriedUser >> /opt/acct/sorry.log
+# logging
+echo "$(/bin/date) - $rootstaffer $sorriedUser" >> /opt/acct/sorry.log
 
 # Notify user by email if email address is available.
 email_from='Open Computing Facility <help@ocf.berkeley.edu>'
@@ -125,7 +123,7 @@ Please do not share your password with anyone or over email.
 $(python3 -c 'import ocflib.misc.mail as mail; print(mail.MAIL_SIGNATURE)')
 EOF
 
-if [ -z $SORRY_KRB5CCNAME ]; then
+if [ -z "$SORRY_KRB5CCNAME" ]; then
     $KDESTROY
 fi
 

--- a/staff/acct/sorry/unsorry
+++ b/staff/acct/sorry/unsorry
@@ -3,106 +3,93 @@
 #Script for unsorrying OCF user accounts, adapted for ldap/kerberos
 #gfs, 3-24-08
 
-LDAPMODIFY=`which ldapmodify`
-KINIT=`which kinit`
-KDESTROY=`which kdestroy`
+LDAPMODIFY=$(which ldapmodify)
+KINIT=$(which kinit)
+KDESTROY=$(which kdestroy)
 
 defaultshell=/bin/bash
 
 # tests for root
-if [[ `/usr/bin/id -u` -ne 0 ]]
-then echo "You must be root to run this"
-exit 2
+if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+    echo "You must be root to run this"
+    exit 2
 fi
 
 
 #usage block
-if [[ $1 = "" ]]
-then
-echo "Usage: $0 [user to be unsorried]"
-exit 0
+if [[ $1 = "" ]]; then
+    echo "Usage: $0 [user to be unsorried]"
+    exit 0
 fi
 
 sorriedUser=$1
 
-if [ -z "`getent passwd $sorriedUser`" ]; then
-  echo "User $sorriedUser does not exist"
-  exit 3
+if [ -z "$(getent passwd "$sorriedUser")" ]; then
+    echo "User $sorriedUser does not exist"
+    exit 3
 fi
 
-userdir=`ldapsearch -x uid=$sorriedUser | grep homeDirectory | cut -d' ' -f2`
+userdir=$(ldapsearch -x uid="$sorriedUser" | grep homeDirectory | cut -d' ' -f2)
 
 #nohome directory case
-if [[ $userdir == "" ]]
-then echo "Could not find the home directory for user $sorriedUser"
-exit 2
+if [[ $userdir == "" ]]; then
+    echo "Could not find the home directory for user $sorriedUser"
+    exit 2
 fi
 
-if [[ ! -e $userdir/.sorry ]]
-then echo "WARNING: User has no .sorry file"
+if [[ ! -e $userdir/.sorry ]]; then
+    echo "WARNING: User has no .sorry file"
 fi
 
 echo "Please ensure that following attributes in LDAP are UP-TO-DATE."
 echo "  for individuals   : calnetuid,  mail"
 echo "  for student groups: callinkoid, mail"
 echo "Press enter to continue, or Ctrl-C to abort"
-read dummy
+read -r _
 
 rootstaffer="$SUDO_USER"
 
-if [ x"$rootstaffer" = x"root" -o -z $rootstaffer ]
-then
-        echo "The sorry.log is much more useful when it logs who you are"
-        echo "rather than simply 'root'. Please enter your username:"
-        read rootstaffer
+if [ x"$rootstaffer" = x"root" ] || [ -z "$rootstaffer" ]; then
+    echo "The sorry.log is much more useful when it logs who you are"
+    echo "rather than simply 'root'. Please enter your username:"
+    read -r rootstaffer
 fi
 
-echo You are $rootstaffer
+echo "You are $rootstaffer"
 
-$KINIT ${rootstaffer}/admin
+$KINIT "${rootstaffer}/admin"
 if [ $? -ne 0 ]; then
     echo "kinit failed, bailing out!"
     exit 1
 fi
 
-#stealing luns's sed madness from makehttp wrapper
-httpdir=`echo $sorriedUser | sed -e 's%\(\(.\)\)%/services/http/users/\2/\1%'`
-#ftpdir=`echo $sorriedUser | sed -e 's%\(\(.\)\)%/services/ftp/users/\2/\1%'`
-#mysqldir=/services/mysql/data/$sorriedUser
+# stealing luns's sed madness from makehttp wrapper
+httpdir="${sorriedUser//\(\(.\)\)/\/services\/http\/users\/\2/\1}"
 
 echo ""
 echo "Changing user's shell back to normal"
-if [[ -e $userdir/.oldshell ]]
-then
-    shell=`cat $userdir/.oldshell | rev | cut -d/ -f1 | rev`
-    if [[ "$shell" == "tcsh" ]]
-    then
+if [[ -e $userdir/.oldshell ]]; then
+    shell=$(rev "$userdir/.oldshell" | cut -d/ -f1 | rev)
+    if [[ "$shell" == "tcsh" ]]; then
         newshell="/bin/tcsh"
-    elif [[ "$shell" == "zsh" ]]
-    then
+    elif [[ "$shell" == "zsh" ]]; then
         newshell="/bin/zsh"
-    elif [[ "$shell" == "csh" ]]
-    then
+    elif [[ "$shell" == "csh" ]]; then
         newshell="/bin/tcsh"
-    elif [[ "$shell" == "ksh" ]]
-    then
+    elif [[ "$shell" == "ksh" ]]; then
         newshell="/bin/bash"
-    elif [[ "$shell" == "bash" ]]
-    then
+    elif [[ "$shell" == "bash" ]]; then
         newshell="/bin/bash"
     else
         newshell=$defaultshell
     fi
 else
-echo ".oldshell file not found, setting shell to $defaultshell"
-newshell=$defaultshell
+    echo ".oldshell file not found, setting shell to $defaultshell"
+    newshell=$defaultshell
 fi
 
 echo ""
 echo "Restoring ownership of passwd entry"
-
-#echo ""
-#echo "Reenabling SMB account"
 
 $LDAPMODIFY -H ldaps://ldap.ocf.berkeley.edu <<EOF
 dn: uid=$sorriedUser,ou=People,dc=OCF,dc=Berkeley,dc=EDU
@@ -114,56 +101,29 @@ replace: gidNumber
 gidNumber: 1000
 EOF
 
-#-
-#replace: sambaAcctFlags
-#sambaAcctFlags: [U          ]
-
-#restoring permission to 755
-chmod 755 $userdir
-
+# restoring permission to 755
+chmod 755 "$userdir"
 
 echo ""
 echo "Restoring services directory permissions:"
-
-if [[ -d $httpdir ]]
-then chmod 755 $httpdir
+if [[ -d $httpdir ]]; then
+    chmod 755 "$httpdir"
 fi
-
-#if [[ -d $ftpdir ]]
-#then chmod 755 $ftpdir
-#fi
-
-#if [[ -d $mysqldir ]]
-#then chmod 755 $mysqldir
-#fi
-
-#echo "Enabling mail for user"
-#grep -v ^$1\$ /var/mail/etc/sorry > /var/mail/etc/sorry.$$
-#chmod 644 /var/mail/etc/sorry.$$
-#chown root:sys /var/mail/etc/sorry.$$
-#mv /var/mail/etc/sorry.$$ /var/mail/etc/sorry
 
 echo ""
 echo "Removing .sorry and .oldshell files"
 
-rm $userdir/.sorry
-rm $userdir/.oldshell
+rm "$userdir/.sorry"
+rm "$userdir/.oldshell"
 
 echo ""
 echo "Final system check:"
-finger -m $sorriedUser
-ldapsearch -x uid=$sorriedUser
-ls -la $userdir
-ls -ld $httpdir
-#ls -ld $ftpdir
-#ls -ld $mysqldir
+finger -m "$sorriedUser"
+ldapsearch -x uid="$sorriedUser"
+ls -la "$userdir"
+ls -ld "$httpdir"
 
-#echo ""
-#echo ""
-#echo "For immediate mail enabling log in to sandstorm and run"
-#echo "  sudo nscd -i passwd && /etc/postfix/ocfconfig/update-sorried.sh"
-
-echo `/bin/date` + $rootstaffer $sorriedUser >> /opt/acct/sorry.log
+echo "$(/bin/date) + $rootstaffer $sorriedUser" >> /opt/acct/sorry.log
 
 $KDESTROY
 

--- a/staff/mail/build-vhost-mail
+++ b/staff/mail/build-vhost-mail
@@ -11,24 +11,24 @@ uncomment() {
   egrep -v '^[[:space:]]*(#|$)' "$1"
 }
 
-vhost_users="`uncomment "$INPUT_FILE" | cut -d' ' -f1`"
+vhost_users="$(uncomment "$INPUT_FILE" | cut -d' ' -f1)"
 
 # exit if invalid users
-if ! getent passwd $vhost_users > /dev/null; then
+if ! getent passwd "$vhost_users" > /dev/null; then
   echo "Error: Invalid vhost users." && \
   echo "Please fix $INPUT_FILE and try again." && \
   exit 1
 fi
 
 # print and exit if sorried users
-if getent passwd $vhost_users | grep sorry; then
+if getent passwd "$vhost_users" | grep sorry; then
   echo "Error: Above vhost users are sorried."
   echo "Please fix $INPUT_FILE and try again."
   exit 1
 fi
 
 # print and exit if vhost users over quota
-if echo $vhost_users | grep -Fx -f - /var/mail/etc/quota; then
+if echo "$vhost_users" | grep -Fx -f - /var/mail/etc/quota; then
   echo "Error: Above vhost users are over quota."
   echo "Please fix $INPUT_FILE and try again."
   exit 1

--- a/staff/puppet/gen-keytab
+++ b/staff/puppet/gen-keytab
@@ -6,18 +6,18 @@ set -euo pipefail
 # TODO: Change to new share when on new puppetmaster
 PRIV_SHARE="/opt/puppet/shares/private"
 
-read -p 'Your username: ' user
+read -rp 'Your username: ' user
 echo 'List of hosts (leave off domain) to generate principals for, separated by spaces:'
-read hostnames
+read -r hostnames
 
 cd $PRIV_SHARE
 for host in $hostnames; do
-  mkdir -p $host
+  mkdir -p "$host"
   echo "Creating host/$host.ocf.berkeley.edu principal"
-  kadmin -p $user/admin add -r --use-defaults host/$host.ocf.berkeley.edu
+  kadmin -p "$user/admin" add -r --use-defaults "host/$host.ocf.berkeley.edu"
   echo "Exporting host/$host.ocf.berkeley.edu keytab"
-  rm -f $host/krb5.keytab
-  kadmin -p $user/admin ext_keytab -k $host/krb5.keytab host/$host.ocf.berkeley.edu
+  rm -f "$host/krb5.keytab"
+  kadmin -p "$user/admin" ext_keytab -k "$host/krb5.keytab" "host/$host.ocf.berkeley.edu"
 done
 
 chown -R puppet:puppet $PRIV_SHARE

--- a/staff/puppet/gen-rootpw
+++ b/staff/puppet/gen-rootpw
@@ -10,7 +10,7 @@ echo "This will update the root password for ALL OCF MACHINES."
 echo "    YOU PROBABLY SHOULD NOT BE RUNNING THIS COMMAND."
 echo "########################################################"
 echo
-read -p "Are you sure you want to do this? [yN] " answer
+read -rp "Are you sure you want to do this? [yN] " answer
 
 if [ "$answer" != "y" ]; then
     echo "Wise choice."

--- a/staff/sys/ldap-add-host
+++ b/staff/sys/ldap-add-host
@@ -22,7 +22,7 @@ environment: production"
 
 echo "$record"
 echo "======================"
-read -p "Add new record? [yN] " choice
+read -rp "Add new record? [yN] " choice
 
 if [ "$choice" != "y" ] && [ "$choice" != "yes" ]; then
     echo "Aborted."

--- a/sys/how
+++ b/sys/how
@@ -9,7 +9,7 @@
 set -e
 
 usage(){
-  echo "Usage: '`basename $0` [PAGER] COMMAND'"
+  echo "Usage: '$(basename "$0") [PAGER] COMMAND'"
   echo "PAGER is the program you use to view or edit (or run) files"
   echo "If ommitted, PAGER is less."
 }
@@ -32,7 +32,7 @@ elif [ $# -eq 2 ]; then
 fi
 
 # find file in PATH
-file="`which "$COMMAND"`"
+file="$(which "$COMMAND")"
 
 # if file does not exist, command does not exist
 if [ -z "$file" ]; then
@@ -44,13 +44,13 @@ fi
 echo "Program found: $file"
 
 # find filetype of file
-filetype=`file -i "$file" | awk '{print $2}' | cut -f 1 -d ';'`
+filetype=$(file -i "$file" | awk '{print $2}' | cut -f 1 -d ';')
 
 if echo "$filetype" | grep -q 'symlink$'; then
 
   # follow symlinks multiple levels to final target and determine type
-  target="`readlink -mn $file`"
-  targettype=`file -bi "$target" | cut -d';' -f1`
+  target="$(readlink -mn "$file")"
+  targettype=$(file -bi "$target" | cut -d';' -f1)
 
   # if chase is installed list chain of symlinks or report
   #if [ -x /usr/bin/chase ]; then
@@ -63,7 +63,7 @@ if echo "$filetype" | grep -q 'symlink$'; then
   echo "Final target@: $target"
 
   # if target is a symlink, it is broken
-  if [ $targettype = 'application/x-symlink' ]; then
+  if [ "$targettype" = 'application/x-symlink' ]; then
     echo "Error: $target is a dangling symlink." 1>&2
     exit 4
   fi
@@ -78,14 +78,14 @@ fi
 echo "MIME filetype: $targettype"
 
 # check for and report binary files
-if [ -z `echo $targettype | grep ^text` ]; then
+if echo "$targettype" | grep -q ^text; then
   echo "Error: Command '$COMMAND' does not refer to a script." 1>&2
   file -b "$target" 1>&2
   exit 2
 fi
 
 # check if pager exists
-if [ -z `which "$PAGER"` ]; then
+if [ -z "$(which "$PAGER")" ]; then
   echo "Error: Pager '$PAGER' could not be found (or not executable) in your PATH." 1>&2
   exit 1
 fi

--- a/update-symlinks
+++ b/update-symlinks
@@ -5,11 +5,11 @@ find bin -type l -delete
 find sbin -type l -delete
 
 find . -type f -executable -not -path './staff/*' -not -path './.git/*' -not -path './vendor/*' -not -path './venv/*' | \
-    while read p; do
+    while read -r p; do
         ln -s "../${p:2}" "bin/$(basename "$p")"
     done
 
 find staff -type f -executable | \
-    while read p; do
+    while read -r p; do
         ln -s "../$p" "sbin/$(basename "$p")"
     done


### PR DESCRIPTION
A bit messy on the first commit because there was a lot to fix, but `shellcheck` should keep our shell scripts more consistent and less error-prone. I'd like to submit a PR upstream to [pre-commit-shell](https://github.com/detailyang/pre-commit-shell) to support using types, because currently it only supports checking files that end in the correct extension:

    files: (\.sh|\.zsh|\.ksh)$