### PR TITLE
stdin2syslog: use TCP again

### DIFF
--- a/staff/sys/stdin2syslog
+++ b/staff/sys/stdin2syslog
@@ -18,4 +18,4 @@ grep -qE '^[a-z0-9_][-a-z0-9_]+$' <<< "$stream" || {
     exit 2
 }
 
-exec logger -d -n syslog -P 514 -t "$stream"
+exec logger -T -n syslog -P 514 -t "$stream"


### PR DESCRIPTION
We used to use TCP in `stdin2syslog`, but we then switched to using UDP in an unsuccessful attempt to solve rt#5913. Shall we switch back to using TCP?