### PR TITLE
Distinguish directors and guests in BoD attendance lists

### DIFF
--- a/staff/meetings/bod
+++ b/staff/meetings/bod
@@ -3,34 +3,33 @@ import argparse
 import sys
 from os.path import join
 
+import bod
 import meetings
 
 
+def get_last_meeting():
+    """Returns a (semester, filename) pair for the most recent meeting."""
+    if not hasattr(get_last_meeting, 'cached_val'):
+        meeting_lst = meetings.get_minutes(bod.get_bod_minutes_path())
+        get_last_meeting.cached_val = (meetings.get_semester(), meeting_lst[-1])
+    return get_last_meeting.cached_val
+
+
 def quorum(args):
-    print(meetings.quorum())
+    print(bod.quorum(*get_last_meeting()))
 
 
 def ls(args):
-    pairs = meetings.ls(args.state).items()
-    pairs = sorted(pairs, key=meetings.membership_key, reverse=True)
-    for user, status in pairs:
-        # current max acct length is 16
-        print('{}  {}'.format(user.ljust(16), status))
+    for director in sorted(bod.ls(*get_last_meeting())):
+        print(director)
 
 
 def danger(args):
-    path = meetings.get_bod_minutes_path()
-    minutes = meetings.get_minutes(path)
-    if len(minutes) > 0:
-        bod = set(meetings.ls(state='bod'))
-        attended_last_meeting = set(meetings.attendance(join(path, minutes[-1])))
-        for user in bod - attended_last_meeting:
-            print(user)
+    on_bod = bod.ls(*get_last_meeting())
+    at_last_meeting = set(bod.get_attending_directors(*get_last_meeting()))
 
-
-def update(args):
-    """update membership file based on minutes in current semester"""
-    meetings.update_membership()
+    for director in sorted(on_bod - at_last_meeting):
+        print(director)
 
 
 if __name__ == '__main__':
@@ -40,19 +39,14 @@ if __name__ == '__main__':
         # lists people in "danger" of being kicked off
         # i.e. people who missed last meeting on bod
         'danger': danger,
-        'update': update,
     }
 
     parser = argparse.ArgumentParser(description='View bod composition and information')
     subparser = parser.add_subparsers(dest='command', help='command to run')
     subparser_danger = subparser.add_parser('danger', help='users in danger of being kicked off bod')
-    subparser_update = subparser.add_parser('update', help='update membership file')
     subparser_ls = subparser.add_parser('ls', help='list users and their bod eligibility state')
     subparser_quorum = subparser.add_parser('quorum', help='current bod quorum')
-    subparser_ls.add_argument('state', nargs='?', default='all',
-                              choices=['all', 'bod', 'offbod'],
-                              help='group of users to list'
-                              )
+
     if len(sys.argv) == 1:
         parser.print_help()
     else:

--- a/staff/meetings/bod
+++ b/staff/meetings/bod
@@ -14,8 +14,8 @@ def ls(args):
     pairs = meetings.ls(args.state).items()
     pairs = sorted(pairs, key=meetings.membership_key, reverse=True)
     for user, status in pairs:
-        # max acct length is 16
-        print('{:16}  {}'.format(user, status))
+        # current max acct length is 16
+        print('{}  {}'.format(user.ljust(16), status))
 
 
 def danger(args):

--- a/staff/meetings/bod.py
+++ b/staff/meetings/bod.py
@@ -1,0 +1,139 @@
+"""Module for BoD meeting logic."""
+import os
+import shutil
+from collections import defaultdict
+from math import ceil
+from os.path import join
+
+import meetings
+
+
+# Max length of usernames
+USERNAME_LEN = 16
+
+
+def ls(state='all'):
+    """Lists everyone with the given membership state.
+
+    Args:
+        state: the membership state. 'all' lists all attendees regardless of
+               state.
+
+    Returns:
+        A list of BoD attendees with the given membership state
+
+    """
+    states = get_membership()
+    if state != 'all':
+        states = {k: v for k, v in states.items() if v == state}
+    return states
+
+
+def quorum():
+    """Returns the quorum for this BoD meeting."""
+    bod = ls(state='bod')
+    return int(ceil(2 / 3 * len(bod)))
+
+
+def get_bod_minutes_path(semester=meetings.get_semester()):
+    """Gets the path to the BoD minutes directory for the given semester."""
+    return meetings.get_minutes_path('bod', semester=semester)
+
+
+def get_membership_file(semester=meetings.get_semester()):
+    """Gets the BoD membership file for the given semester."""
+    folder = get_bod_minutes_path(semester=semester)
+    path = join(folder, 'membership')
+    return path
+
+
+def get_membership(semester=meetings.get_semester()):
+    """Get the membership status for every BoD attendee for the given semester.
+
+    Args:
+        semester: The specified semester. Defaults to the current semester.
+
+    Returns:
+        A dictionary of (attendee, state) mappings.
+    """
+    status = defaultdict(int)
+    path = get_membership_file(semester=semester)
+    if not os.path.exists(path):
+        handle_new_semester()
+    with open(path) as f:
+        for line in f:
+            user, state = line.split()
+            status[user] = state
+    return status
+
+
+def handle_new_semester():
+    """Sets up a semester's directory.
+
+    Currently copies the BoD membership file from the previous semester.
+    """
+    new_file = get_membership_file()
+    old_file = get_membership_file(semester=meetings.get_prev_semester())
+    shutil.copyfile(old_file, new_file)
+    os.chmod(new_file, 0o664)
+
+
+def update_membership():
+    """Updates the membership file for the current semester.
+
+    Uses the attendance list for the current meeting to update the membership
+    file for the current semester.
+    """
+    cur_status = get_membership()
+    bod_members = {member for member, status in cur_status.items()
+                   if status == 'bod'}
+
+    minutes_path = get_bod_minutes_path()
+    minutes_files = meetings.get_minutes(minutes_path)
+    if minutes_files:
+        attendees_today = meetings.get_attendance(join(minutes_path,
+                                                       minutes_files[-1]))
+
+    # Start new status dict. Begin by adding all BoD members.
+    new_status = {member: status for member, status in cur_status.items()
+                  if status == 'bod'}
+
+    # Add new members to BoD
+    guests = attendees_today - bod_members
+    for attendee in guests:
+        reply = input(attendee + ' is not on BoD. Would they like to join? '
+                      '(y/n) ')
+        if reply == 'y' or reply == 'yes':
+            new_status[attendee] = 'bod'
+
+    # Kick people off BoD if they haven't come to the previous 2 meetings
+    # (including the current one)
+    if len(minutes_files) >= 2:
+        attended_last_meeting = meetings.get_attendance(join(minutes_path,
+                                                             minutes_files[-2]))
+    else:
+        last_semester_minutes_path = get_bod_minutes_path(
+            meetings.get_prev_semester())
+        last_semester_minutes = meetings.get_minutes(last_semester_minutes_path)
+        assert len(last_semester_minutes) > 1, \
+            'Expecting at least one BoD meeting last semester'
+        attended_last_meeting = meetings.get_attendance(
+            join(last_semester_minutes_path, last_semester_minutes[-1]))
+
+    for non_attendee in bod_members - (attendees_today | attended_last_meeting):
+        del new_status[non_attendee]
+
+    # Write out new status
+    def membership_key(p):
+        special = {'bod': 0, 'offbod': 1}
+        u, s = p
+        if s in special:
+            s = special[s]
+        return (s, u)
+    sorted_new_status = sorted(new_status.items(), key=membership_key)
+    str_new_status = ''.join('{}  {}\n'.format(attendee.ljust(USERNAME_LEN),
+                                               status)
+                             for attendee, status in sorted_new_status)
+
+    with open(get_membership_file(), 'w') as f:
+        f.write(str_new_status)

--- a/staff/meetings/bod.py
+++ b/staff/meetings/bod.py
@@ -1,37 +1,21 @@
 """Module for BoD meeting logic."""
-import os
-import shutil
-from collections import defaultdict
 from math import ceil
 from os.path import join
 
 import meetings
 
 
-# Max length of usernames
-USERNAME_LEN = 16
-
-
-def ls(state='all'):
-    """Lists everyone with the given membership state.
+def quorum(semester, minutes_filename):
+    """Returns the quorum for the given BoD meeting.
 
     Args:
-        state: the membership state. 'all' lists all attendees regardless of
-               state.
-
-    Returns:
-        A list of BoD attendees with the given membership state
+        semester: the directory name (as given by ``meetings.get_semester()``)
+                  for the semester in which the meeting took place
+        minutes_filename: the filename of the file containing the minutes for
+                          the meeting
 
     """
-    states = get_membership()
-    if state != 'all':
-        states = {k: v for k, v in states.items() if v == state}
-    return states
-
-
-def quorum():
-    """Returns the quorum for this BoD meeting."""
-    bod = ls(state='bod')
+    bod = ls(*meetings.get_prev_meeting('bod', semester, minutes_filename))
     return int(ceil(2 / 3 * len(bod)))
 
 
@@ -40,100 +24,160 @@ def get_bod_minutes_path(semester=meetings.get_semester()):
     return meetings.get_minutes_path('bod', semester=semester)
 
 
-def get_membership_file(semester=meetings.get_semester()):
-    """Gets the BoD membership file for the given semester."""
-    folder = get_bod_minutes_path(semester=semester)
-    path = join(folder, 'membership')
-    return path
-
-
-def get_membership(semester=meetings.get_semester()):
-    """Get the membership status for every BoD attendee for the given semester.
+def get_attending_directors(semester, minutes_filename):
+    """Returns a list of directors present at the given meeting.
 
     Args:
-        semester: The specified semester. Defaults to the current semester.
+        semester: the directory name (as given by ``meetings.get_semester()``)
+                  for the semester in which the meeting took place
+        minutes_filename: the filename of the file containing the minutes for
+                          the meeting
+
+    """
+    minutes_file = join(get_bod_minutes_path(semester=semester),
+                        minutes_filename)
+    attendees = []
+    with open(minutes_file, 'r') as fin:
+        # Skip everything before the line "Directors in attendance:"
+        for line in fin:
+            if line == 'Directors in attendance:\n':
+                break
+
+        for line in fin:
+            if line.strip():
+                attendees.append(line.strip())
+            else:
+                break
+
+    assert attendees, 'A BoD meeting needs at least one director present'
+    return attendees
+
+
+def get_attending_guests(semester, minutes_filename):
+    """Returns lists of guests present at the given meeting.
+
+    Args:
+        semester: the directory name (as given by ``meetings.get_semester()``)
+                  for the semester in which the meeting took place
+        minutes_filename: the filename of the file containing the minutes for
+                          the meeting
 
     Returns:
-        A dictionary of (attendee, state) mappings.
+        A tuple of two lists. The first list is of guests appointed to BoD at
+        that meeting, the second list is of all other guests.
+
     """
-    status = defaultdict(int)
-    path = get_membership_file(semester=semester)
-    if not os.path.exists(path):
-        handle_new_semester()
-    with open(path) as f:
-        for line in f:
-            user, state = line.split()
-            status[user] = state
-    return status
+    minutes_file = join(get_bod_minutes_path(semester=semester),
+                        minutes_filename)
+    joined = []
+    visiting = []
+    with open(minutes_file, 'r') as fin:
+        # Skip everything before the line "Guests in attendance:"
+        for line in fin:
+            if line == 'Guests in attendance:\n':
+                break
+
+        for line in fin:
+            line = line.strip()
+            if line:
+                if line.endswith('*'):
+                    joined.append(line[:-1])
+                else:
+                    visiting.append(line)
+            else:
+                break
+
+    return (joined, visiting)
 
 
-def handle_new_semester():
-    """Sets up a semester's directory.
+def ls(semester, minutes_filename):
+    """Lists everyone on BoD at the conclusion of the given meeting.
 
-    Currently copies the BoD membership file from the previous semester.
+    Args:
+        semester: the directory name (as given by ``meetings.get_semester()``)
+                  for the semester in which the meeting took place
+        minutes_filename: the filename of the file containing the minutes for
+                          the meeting
+
+    Returns:
+        A set of BoD members as specified above
+
     """
-    new_file = get_membership_file()
-    old_file = get_membership_file(semester=meetings.get_prev_semester())
-    shutil.copyfile(old_file, new_file)
-    os.chmod(new_file, 0o664)
+    prev_sem, prev_fname = meetings.get_prev_meeting('bod', semester,
+                                                     minutes_filename)
+
+    # FIXME: Always include the GM and SM on this list
+    # (And the ASUC EVP and CFO if we want to be pedantic)
+    prev_on_bod = set(get_attending_directors(prev_sem, prev_fname)
+                      + get_attending_guests(prev_sem, prev_fname)[0])
+    cur_on_bod = set(get_attending_directors(semester, minutes_filename)
+                     + get_attending_guests(semester, minutes_filename)[0])
+    return prev_on_bod | cur_on_bod
 
 
-def update_membership():
-    """Updates the membership file for the current semester.
+def split_attendance(semester, minutes_filename):
+    """Splits the attendance section for the given meeting's minutes.
 
-    Uses the attendance list for the current meeting to update the membership
-    file for the current semester.
+    Splits the attendance section into a section for BoD members, a
+    section for guests joining BoD, and a section for guests not joining
+    BoD.
+
+    Args:
+        minutes_filename: the file containing the minutes for the meeting
+
+    Returns:
+        A tuple of two lists. The first list is of guests appointed to BoD at
+        that meeting, the second list is of all other guests.
+
     """
-    cur_status = get_membership()
-    bod_members = {member for member, status in cur_status.items()
-                   if status == 'bod'}
+    minutes_file = join(get_bod_minutes_path(semester=semester),
+                        minutes_filename)
+    with open(minutes_file, 'r') as fin:
+        lines = fin.readlines()
 
-    minutes_path = get_bod_minutes_path()
-    minutes_files = meetings.get_minutes(minutes_path)
-    if minutes_files:
-        attendees_today = meetings.get_attendance(join(minutes_path,
-                                                       minutes_files[-1]))
+    attendance_start = lines.index('Attendance:\n')
+    attendance_end = attendance_start + 1
+    while (attendance_end < len(lines)
+           and lines[attendance_end].strip()):
+        attendance_end += 1
+    attendees = {l.strip()
+                 for l in lines[attendance_start + 1:attendance_end]}
 
-    # Start new status dict. Begin by adding all BoD members.
-    new_status = {member: status for member, status in cur_status.items()
-                  if status == 'bod'}
+    replacement_lines = []
 
-    # Add new members to BoD
-    guests = attendees_today - bod_members
-    for attendee in guests:
-        reply = input(attendee + ' is not on BoD. Would they like to join? '
-                      '(y/n) ')
+    replacement_lines.append('Directors in attendance:\n')
+    on_bod = set(ls(*meetings.get_prev_meeting('bod', semester,
+                                               minutes_filename)))
+    for director in sorted(attendees & on_bod):
+        replacement_lines.append(director + '\n')
+    replacement_lines.append('\n')
+
+    guests = attendees - on_bod
+    appointed_guests = []
+    visiting_guests = []
+    for guest in sorted(guests):
+        reply = None
+        while reply not in {'y', 'yes', 'n', 'no'}:
+            reply = input(guest + ' is not on BoD. Would they like to join? '
+                          '(y/n) ')
         if reply == 'y' or reply == 'yes':
-            new_status[attendee] = 'bod'
+            appointed_guests.append(guest)
+        else:
+            visiting_guests.append(guest)
 
-    # Kick people off BoD if they haven't come to the previous 2 meetings
-    # (including the current one)
-    if len(minutes_files) >= 2:
-        attended_last_meeting = meetings.get_attendance(join(minutes_path,
-                                                             minutes_files[-2]))
-    else:
-        last_semester_minutes_path = get_bod_minutes_path(
-            meetings.get_prev_semester())
-        last_semester_minutes = meetings.get_minutes(last_semester_minutes_path)
-        assert len(last_semester_minutes) > 1, \
-            'Expecting at least one BoD meeting last semester'
-        attended_last_meeting = meetings.get_attendance(
-            join(last_semester_minutes_path, last_semester_minutes[-1]))
+    if appointed_guests or visiting_guests:
+        replacement_lines.append('Guests in attendance:\n')
+        for guest in appointed_guests:
+            replacement_lines.append(guest + '*\n')
+        for guest in visiting_guests:
+            replacement_lines.append(guest + '\n')
+        replacement_lines.append('\n')
+        replacement_lines.append('Guests marked with a * were appointed to '
+                                 'BoD.\n')
 
-    for non_attendee in bod_members - (attendees_today | attended_last_meeting):
-        del new_status[non_attendee]
+    # Replace attendance block in lines with the replacement lines
+    lines[attendance_start:attendance_end] = replacement_lines
 
-    # Write out new status
-    def membership_key(p):
-        special = {'bod': 0, 'offbod': 1}
-        u, s = p
-        if s in special:
-            s = special[s]
-        return (s, u)
-    sorted_new_status = sorted(new_status.items(), key=membership_key)
-    str_new_status = ''.join('{}  {}\n'.format(attendee.ljust(USERNAME_LEN),
-                                               status)
-                             for attendee, status in sorted_new_status)
-
-    with open(get_membership_file(), 'w') as f:
-        f.write(str_new_status)
+    with open(minutes_file, 'w') as fout:
+        for line in lines:
+            fout.write(line)

--- a/staff/meetings/meetings.py
+++ b/staff/meetings/meetings.py
@@ -104,6 +104,40 @@ def get_minutes(folder):
     return sorted(i for i in os.listdir(folder) if pattern.match(i))
 
 
+def get_prev_meeting(choice, semester, minutes_filename):
+    """Gets the semester and minutes filename of the previous meeting.
+
+    Args:
+        choice: the meeting type
+        semester: the directory name (as given by ``meetings.get_semester()``)
+                  for the semester in which the meeting took place
+        minutes_filename: the filename of the file containing the minutes for
+                          the meeting
+
+    Returns:
+        A tuple of (semester of previous meeting, filename of previous meeting
+        minutes)
+
+    """
+    minutes = get_minutes(get_minutes_path(choice, semester=semester))
+    try:
+        i = minutes.index(minutes_filename)
+    except IndexError:
+        raise ValueError('The minutes file "{}" was not found'
+                         .format(minutes_filename))
+
+    if i > 0:
+        semester_prev = semester
+        prev_meeting_file = minutes[i - 1]
+    else:
+        semester_prev = get_prev_semester(semester=semester)
+        prev_minutes = get_minutes(get_minutes_path(choice,
+                                                    semester=semester_prev))
+        prev_meeting_file = prev_minutes[-1]
+
+    return (semester_prev, prev_meeting_file)
+
+
 def get_attendance(path):
     """Returns the set of attendees for the given meeting.
 

--- a/staff/meetings/meetings.py
+++ b/staff/meetings/meetings.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from datetime import datetime
 from getpass import getuser
@@ -9,7 +10,6 @@ from os import umask
 from os.path import exists
 from os.path import expanduser
 from os.path import join
-from re import compile
 from shutil import copyfile
 from string import Template
 from time import strftime
@@ -20,10 +20,25 @@ USERNAME_LEN = 16
 
 
 def get_minutes_folder():
+    """Returns the path to the folder containing minutes.
+
+    Note that bod (which is stored in public_html, as they are readable on the
+    Web) is symlinked in this folder.
+    """
     return expanduser('~staff/minutes')
 
 
 def ls(state='all'):
+    """Lists everyone with the given membership state.
+
+    Args:
+        state: the membership state. 'all' lists all attendees regardless of
+               state.
+
+    Returns:
+        A list of BoD attendees with the given membership state
+
+    """
     states = get_bod_membership()
     if state != 'all':
         states = {k: v for k, v in states.items() if v == state}
@@ -31,11 +46,13 @@ def ls(state='all'):
 
 
 def quorum():
+    """Returns the quorum for this BoD meeting."""
     bod = ls(state='bod')
     return int(ceil(2 / 3 * len(bod)))
 
 
 def get_template(choice):
+    """Returns the path to the template for the given meeting type."""
     minutes_folder = get_minutes_folder()
     if exists(join(minutes_folder, choice, 'template')):
         return join(minutes_folder, choice, 'template')
@@ -43,10 +60,15 @@ def get_template(choice):
 
 
 def get_minutes_choices():
+    """Returns the choices available for meeting type."""
     return listdir(get_minutes_folder())
 
 
 def get_semester():
+    """Returns the directory name for the current semester
+
+    For example: 2017/Fall
+    """
     now = datetime.now()
     year = now.year
     month = now.month
@@ -65,10 +87,13 @@ def get_semester():
 
 
 def get_bod_minutes_path(semester=get_semester()):
+    """Gets the path to the BoD minutes directory for the given semester."""
     return get_minutes_path('bod', semester=semester)
 
 
 def get_minutes_path(choice, semester=get_semester()):
+    """Gets the path to the minutes directory for the given type and semester.
+    """
     path = join(get_minutes_folder(), choice)
     if not exists(path):
         raise ValueError('argument must be from get_minutes_choices()')
@@ -83,10 +108,12 @@ def get_minutes_path(choice, semester=get_semester()):
 
 
 def get_minutes_file():
+    """Gets the filename for the current minutes."""
     return strftime('%Y-%m-%d')
 
 
 def get_bod_membership_file(semester=get_semester()):
+    """Gets the BoD membership file for the given semester."""
     folder = get_bod_minutes_path(semester=semester)
     path = join(folder, 'membership')
     return path
@@ -126,11 +153,20 @@ def get_minutes(folder):
         list: The sorted list of minutes files in the folder
 
     """
-    pattern = compile('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
-    return sorted([i for i in listdir(folder) if pattern.match(i)])
+    pattern = re.compile('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+    return sorted(i for i in listdir(folder) if pattern.match(i))
 
 
-def attendance(path):
+def get_attendance(path):
+    """Returns the set of attendees for the given meeting.
+
+    Args:
+        path: path to the minutes file for the desired meeting
+
+    Returns:
+        A set containing the usernames of everyone who attended that meeting
+
+    """
     attended = set()
     with open(path) as f:
         lines = f.read().splitlines()
@@ -157,6 +193,10 @@ def get_prev_semester(semester=get_semester()):
 
 
 def new_semester():
+    """Sets up a semester's directory.
+
+    Currently copies the BoD membership file from the previous semester.
+    """
     new_file = get_bod_membership_file()
     old_file = get_bod_membership_file(semester=get_prev_semester())
     copyfile(old_file, new_file)
@@ -164,30 +204,45 @@ def new_semester():
 
 
 def minutes_setup(notes, choice):
+    # Create minutes file from template if it doesn't exist
     if not exists(notes):
         copyfile(get_template(choice), notes)
         chmod(notes, 0o644)
+
     with open(notes, 'r') as f:
         s = Template(f.read())
+
+    # Substitute values
     subs = {'username': getuser(), 'start_time': strftime('%H:%M')}
     if choice == 'bod':
         subs['quorum'] = str(quorum())
     s = s.safe_substitute(subs)
+
+    # Write out file with substituted values
     with open(notes, 'w') as f:
         f.write(s)
 
 
 def minutes_done(notes, choice):
+    # Substitute in ending values
     with open(notes, 'r') as f:
         s = Template(f.read())
     s = s.safe_substitute(end_time=strftime('%H:%M'))
+
+    # Write out file with substituted values
     with open(notes, 'w') as f:
         f.write(s)
+
     if choice == 'bod':
         update_membership()
 
 
 def update_membership():
+    """Updates the membership file for the current semester.
+
+    Uses the attendance list for the current meeting to update the membership
+    file for the current semester.
+    """
     cur_status = get_bod_membership()
     bod_members = {member for member, status in cur_status.items()
                    if status == 'bod'}
@@ -196,7 +251,7 @@ def update_membership():
     minutes_files = get_minutes(minutes_path)
     if minutes_files:
         print(join(minutes_path, minutes_files[-1]))
-        attendees_today = attendance(join(minutes_path, minutes_files[-1]))
+        attendees_today = get_attendance(join(minutes_path, minutes_files[-1]))
 
     # Start new status dict. Begin by adding all BoD members.
     new_status = {member: status for member, status in cur_status.items()
@@ -214,15 +269,15 @@ def update_membership():
     # (including the current one)
     if len(minutes_files) >= 2:
         print(join(minutes_path, minutes_files[-2]))
-        attended_last_meeting = attendance(join(minutes_path,
-                                                minutes_files[-2]))
+        attended_last_meeting = get_attendance(join(minutes_path,
+                                                    minutes_files[-2]))
     else:
         last_semester_minutes_path = get_bod_minutes_path(get_prev_semester())
         last_semester_minutes = get_minutes(last_semester_minutes_path)
         assert len(last_semester_minutes) > 1, \
             'Expecting at least one BoD meeting last semester'
-        attended_last_meeting = attendance(join(last_semester_minutes_path,
-                                                last_semester_minutes[-1]))
+        attended_last_meeting = get_attendance(join(last_semester_minutes_path,
+                                                    last_semester_minutes[-1]))
 
     print(attendees_today)
     print(attended_last_meeting)

--- a/staff/meetings/minutes
+++ b/staff/meetings/minutes
@@ -4,13 +4,59 @@
 This script opens up an editor for taking minutes in the appropriate file.
 It also performs setup and teardown operations, particularly in the case of BoD minutes.
 """
+import getpass
 import os
+import shutil
 import subprocess
 import sys
+import time
+from os.path import join
+from string import Template
 
 from ocflib.misc.shell import get_editor
 
+import bod
 import meetings
+
+
+def minutes_setup(choice, semester, filename):
+    notes = join(meetings.get_minutes_path(choice, semester=semester),
+                 filename)
+
+    # Create minutes file from template if it doesn't exist
+    if not os.path.exists(notes):
+        shutil.copyfile(meetings.get_template(choice), notes)
+        os.chmod(notes, 0o644)
+
+    with open(notes, 'r') as f:
+        s = Template(f.read())
+
+    # Substitute values
+    subs = {'username': getpass.getuser(), 'start_time': time.strftime('%H:%M')}
+    if choice == 'bod':
+        subs['quorum'] = str(bod.quorum())
+    s = s.safe_substitute(subs)
+
+    # Write out file with substituted values
+    with open(notes, 'w') as f:
+        f.write(s)
+
+
+def minutes_done(choice, semester, filename):
+    notes = join(meetings.get_minutes_path(choice, semester=semester),
+                 filename)
+
+    # Substitute in ending values
+    with open(notes, 'r') as f:
+        s = Template(f.read())
+    s = s.safe_substitute(end_time=time.strftime('%H:%M'))
+
+    # Write out file with substituted values
+    with open(notes, 'w') as f:
+        f.write(s)
+
+    if choice == 'bod':
+        bod.update_membership()
 
 
 def main():
@@ -23,11 +69,13 @@ def main():
         print('Invalid choice.')
         return 1
 
+    semester = meetings.get_semester()
     filename = meetings.get_minutes_file()
-    filepath = os.path.join(meetings.get_minutes_path(choice), filename)
-    meetings.minutes_setup(filepath, choice)
+    filepath = join(meetings.get_minutes_path(choice, semester=semester),
+                    filename)
+    minutes_setup(choice, semester, filename)
     subprocess.call([get_editor(), filepath])
-    meetings.minutes_done(filepath, choice)
+    minutes_done(choice, semester, filename)
 
 
 if __name__ == '__main__':

--- a/staff/meetings/minutes
+++ b/staff/meetings/minutes
@@ -1,40 +1,34 @@
 #!/usr/bin/env python3
-import os
-from subprocess import call
-from sys import exit
+"""Script for recording meeting minutes.
 
-import meetings
+This script opens up an editor for taking minutes in the appropriate file.
+It also performs setup and teardown operations, particularly in the case of BoD minutes.
+"""
+import os
+import subprocess
+import sys
+
 from ocflib.misc.shell import get_editor
 
-# note that bod (which is stored in public_html, as they are publicly
-# readable) is symlinked in this folder
-
-# bod template file
+import meetings
 
 
 def main():
-
-    path = os.path.expanduser('~staff/minutes')
-    options = os.listdir(path)
+    options = meetings.get_minutes_choices()
 
     print('What are you taking notes for?')
     print('Options:', ', '.join(options))
-
-    choice = input()
+    choice = input('Enter choice: ')
     if choice not in options:
-        return(0)
+        print('Invalid choice.')
+        return 1
 
-    path = os.path.join(path, choice)
-
-    name = meetings.get_minutes_file()
-
-    notes = os.path.join(meetings.get_minutes_path(choice), name)
-
-    meetings.minutes_setup(notes, choice)
-
-    call([get_editor(), notes])
-    meetings.minutes_done(notes, choice)
+    filename = meetings.get_minutes_file()
+    filepath = os.path.join(meetings.get_minutes_path(choice), filename)
+    meetings.minutes_setup(filepath, choice)
+    subprocess.call([get_editor(), filepath])
+    meetings.minutes_done(filepath, choice)
 
 
 if __name__ == '__main__':
-    exit(main())
+    sys.exit(main())

--- a/staff/meetings/minutes
+++ b/staff/meetings/minutes
@@ -34,7 +34,7 @@ def minutes_setup(choice, semester, filename):
     # Substitute values
     subs = {'username': getpass.getuser(), 'start_time': time.strftime('%H:%M')}
     if choice == 'bod':
-        subs['quorum'] = str(bod.quorum())
+        subs['quorum'] = str(bod.quorum(semester, filename))
     s = s.safe_substitute(subs)
 
     # Write out file with substituted values
@@ -56,7 +56,7 @@ def minutes_done(choice, semester, filename):
         f.write(s)
 
     if choice == 'bod':
-        bod.update_membership()
+        bod.split_attendance(semester, filename)
 
 
 def main():


### PR DESCRIPTION
This commit makes the minutes script split the "Attendance"
block in BoD minutes. The note-taker still writes a single
Attendance block, like before; however, after they exit the
text editor, the Attendance block is replaced with two blocks,
an attendance block for directors and an attendance block for
guests. Guests are further marked with an asterisk if they
choose to join BoD at that meeting.
    
Major changes have been made to the BoD module. Most notably,
the membership file is eliminated. Membership is now dynamically
determined from the attendance lists in the minutes.
    
One drawback is that you cannot run `minutes` to take BoD minutes
twice in the same day without re-combining the attendance lists,
or else it crashes. This can be remedied in the future.