### PR TITLE
Add setup wordpress script

### DIFF
--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+php_defines() {
+    sed -i "s/$1/$2/" "$WPCONFIG"
+}
+
+WEBROOT=$HOME/public_html
+WPCONFIG=wp-config.php
+USER=$(whoami)
+
+# Create symlink to webroot
+makehttp
+cd "$WEBROOT"
+rm -rf *
+
+# Get SQL password
+SQLPASS=$(echo "yes" | makemysql | tail -n 1 | grep -Po '(?<=: )([0-9a-zA-Z]){24,}$')
+[ -z "$SQLPASS" ] && exit 1
+
+# Install WordPress
+wp core download
+cp wp-config-sample.php "$WPCONFIG"
+
+# dos2unix
+sed -i 's/\r//' "$WPCONFIG"
+
+# Modify the config file with correct info
+php_defines 'database_name_here' "$USER"
+php_defines 'username_here' "$USER"
+php_defines 'password_here' "$SQLPASS"
+php_defines 'localhost' 'mysql'
+php_defines 'utf8' 'utf8mb4'
+
+# Grab auth keys and salts from WP API
+sed -i '/put your unique phrase here/d' "$WPCONFIG"
+echo >> "$WPCONFIG"
+curl -sS -X GET https://api.wordpress.org/secret-key/1.1/salt/ >> "$WPCONFIG"
+

--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Creates symlink to user's webroot. If the symlink exists and files
+# are present in webroot, they are backed up in the user's home directory.
+# A user's database is created or, if it already exists, the password 
+# is reset. WordPress is installed and the wp-config file is filled
+# out with the requisite information. Further configuration can be 
+# done by the user from a browser.  
+#
+# WARNING: This script should generally be run on a account without
+#          an existing website or database!
+#
+
+set -euxo pipefail
+shopt -s dotglob
+
 php_defines() {
     sed -i "s/$1/$2/" "$WPCONFIG"
 }
@@ -11,11 +25,24 @@ USER=$(whoami)
 # Create symlink to webroot
 makehttp
 cd "$WEBROOT"
-rm -rf *
+
+# If user has files, move them to a new location. 
+if [ -n "$(ls -A)" ]; then
+    TS=$(date +"%Y-%m-%d_%H:%M:%S")
+    BACKUP="$HOME/webroot-$TS"
+    mkdir -p "$BACKUP"
+    echo "Webroot not empty. Moving current files to $BACKUP..." 
+    mv ./* "$BACKUP"
+fi
 
 # Get SQL password
+echo "Resetting database..."
 SQLPASS=$(echo "yes" | makemysql | tail -n 1 | grep -Po '(?<=: )([0-9a-zA-Z]){24,}$')
-[ -z "$SQLPASS" ] && exit 1
+if [ -z "$SQLPASS" ]; then
+    echo "  Error: Could not retrieve database password. Run makemysql to see the issue."
+    exit 1
+fi
+echo "SQL set up and the password can be found in $WPCONFIG ..."
 
 # Install WordPress
 wp core download
@@ -36,3 +63,4 @@ sed -i '/put your unique phrase here/d' "$WPCONFIG"
 echo >> "$WPCONFIG"
 curl -sS -X GET https://api.wordpress.org/secret-key/1.1/salt/ >> "$WPCONFIG"
 
+echo "WordPress installed successful. Go to https://www.ocf.berkeley.edu/~$USER to finish the setup process."

--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -14,7 +14,7 @@ shopt -s dotglob
 echo -e "\033[33mWARNING: This script should generally be run on a fresh account!\033[00m"
 echo -e "A user with an existing website or database will have their files
 backed up, but their database password will change and the WordPress
-install may clutter or try to migrate tables.\n"
+install may migrate and reuse existing tables.\n"
 
 read -rp "Are you sure you want to continue? [y/N] " idunno
 idunno=${idunno,,}
@@ -33,15 +33,16 @@ cd "$webroot"
 # Check if user has files and let user decide what they want to do.
 if [[ -n "$(ls -A)" ]]; then
     echo
-    echo -e "\033[33mThere are currently files in webroot!\033[00m\n"
+    echo -e "\033[33mThere are currently files in webroot! These will be backed up.\033[00m\n"
     read -rp "Do you want to continue? [y/N] " whoknows
 
     whoknows=${whoknows,,}
     if [[ "$whoknows" =~ ^(yes|y) ]]; then
         ts=$(date +"%Y-%m-%d_%H:%M:%S")
-        backup="$HOME/webroot-$ts"
+        backup="$HOME/public_html-$ts"
         mkdir -p "$backup"
         echo "Moving current files to $backup ..."
+        # Note that dotglob is set so hidden files are moved too
         mv ./* "$backup"
     else
         echo "Ok, bye!"
@@ -61,6 +62,6 @@ echo "SQL set up and the password can be found in wp-config.php ..."
 # Install WordPress and create config file
 wp core download
 wp config create --dbname="$user" --dbuser="$user" --dbpass="$sqlpass" --dbhost=mysql --dbcharset=utf8mb4
-# Somehow 644 is the default...
+# Somehow 644 is the default... See https://core.trac.wordpress.org/ticket/37264
 chmod 600 "$webroot/wp-config.php"
 echo "WordPress install successful. Go to https://www.ocf.berkeley.edu/~$user to finish the setup process."

--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -2,23 +2,23 @@
 
 # Creates symlink to user's webroot. If the symlink exists and files
 # are present in webroot, they are backed up in the user's home directory.
-# A user's database is created or, if it already exists, the password 
+# A user's database is created or, if it already exists, the password
 # is reset. WordPress is installed and the wp-config file is filled
-# out with the requisite information. Further configuration can be 
-# done by the user from a browser.  
+# out with the requisite information. Further configuration can be
+# done by the user from a browser.
 #
 
 set -euo pipefail
 shopt -s dotglob
 
-echo -e "\033[31mWARNING: This script should generally be run on a fresh account!\033[00m"
-echo -e "A user with an existing website or database will have their files 
-backed up, but their database password will change and the WordPress 
+echo -e "\033[33mWARNING: This script should generally be run on a fresh account!\033[00m"
+echo -e "A user with an existing website or database will have their files
+backed up, but their database password will change and the WordPress
 install may clutter or try to migrate tables.\n"
 
-read -rp "Are you sure you want to continue? [Y/n] " idunno
+read -rp "Are you sure you want to continue? [y/N] " idunno
 idunno=${idunno,,}
-if ! [[ "$idunno" =~ ^(yes|y|^$) ]]; then
+if ! [[ "$idunno" =~ ^(yes|y) ]]; then
     echo "Ok, bye!"
     exit 0
 fi
@@ -30,22 +30,19 @@ user=$(whoami)
 makehttp
 cd "$webroot"
 
-# Check if user has files and let user decide what they want to do. 
+# Check if user has files and let user decide what they want to do.
 if [[ -n "$(ls -A)" ]]; then
     echo
-    echo -e "There are currently files in webroot!\n"
-    read -rp "Do you want to back these files up? [Y/n/x] " whoknows
+    echo -e "\033[33mThere are currently files in webroot!\033[00m\n"
+    read -rp "Do you want to continue? [y/N] " whoknows
 
     whoknows=${whoknows,,}
-    if [[ "$whoknows" =~ ^(yes|y|^$) ]]; then
+    if [[ "$whoknows" =~ ^(yes|y) ]]; then
         ts=$(date +"%Y-%m-%d_%H:%M:%S")
         backup="$HOME/webroot-$ts"
         mkdir -p "$backup"
-        echo "Moving current files to $backup ..." 
+        echo "Moving current files to $backup ..."
         mv ./* "$backup"
-    elif [[ "$whoknows" =~ ^(no|n) ]]; then
-        echo "Ok, say goodbye to your website."
-        rm -rf ./*
     else
         echo "Ok, bye!"
         exit 0
@@ -63,5 +60,7 @@ echo "SQL set up and the password can be found in wp-config.php ..."
 
 # Install WordPress and create config file
 wp core download
-wp config create --dbname="$user" --dbuser="$user" --dbpass="$sqlpass" --dbhost=mysql --dbcharset=utf8mb4 
+wp config create --dbname="$user" --dbuser="$user" --dbpass="$sqlpass" --dbhost=mysql --dbcharset=utf8mb4
+# Somehow 644 is the default...
+chmod 600 "$webroot/wp-config.php"
 echo "WordPress install successful. Go to https://www.ocf.berkeley.edu/~$user to finish the setup process."

--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -14,10 +14,6 @@
 set -euxo pipefail
 shopt -s dotglob
 
-php_defines() {
-    sed -i "s/$1/$2/" "$WPCONFIG"
-}
-
 WEBROOT=$HOME/public_html
 WPCONFIG=wp-config.php
 USER=$(whoami)
@@ -44,23 +40,7 @@ if [ -z "$SQLPASS" ]; then
 fi
 echo "SQL set up and the password can be found in $WPCONFIG ..."
 
-# Install WordPress
+# Install WordPress and create config file
 wp core download
-cp wp-config-sample.php "$WPCONFIG"
-
-# dos2unix
-sed -i 's/\r//' "$WPCONFIG"
-
-# Modify the config file with correct info
-php_defines 'database_name_here' "$USER"
-php_defines 'username_here' "$USER"
-php_defines 'password_here' "$SQLPASS"
-php_defines 'localhost' 'mysql'
-php_defines 'utf8' 'utf8mb4'
-
-# Grab auth keys and salts from WP API
-sed -i '/put your unique phrase here/d' "$WPCONFIG"
-echo >> "$WPCONFIG"
-curl -sS -X GET https://api.wordpress.org/secret-key/1.1/salt/ >> "$WPCONFIG"
-
+wp config create --dbname="$USER" --dbuser="$USER" --dbpass="$SQLPASS" --dbhost=mysql --dbcharset=utf8mb4 
 echo "WordPress installed successful. Go to https://www.ocf.berkeley.edu/~$USER to finish the setup process."

--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -7,40 +7,61 @@
 # out with the requisite information. Further configuration can be 
 # done by the user from a browser.  
 #
-# WARNING: This script should generally be run on a account without
-#          an existing website or database!
-#
 
-set -euxo pipefail
+set -euo pipefail
 shopt -s dotglob
 
-WEBROOT=$HOME/public_html
-WPCONFIG=wp-config.php
-USER=$(whoami)
+echo -e "\033[31mWARNING: This script should generally be run on a fresh account!\033[00m"
+echo -e "A user with an existing website or database will have their files 
+backed up, but their database password will change and the WordPress 
+install may clutter or try to migrate tables.\n"
+
+read -rp "Are you sure you want to continue? [Y/n] " idunno
+idunno=${idunno,,}
+if ! [[ "$idunno" =~ ^(yes|y|^$) ]]; then
+    echo "Ok, bye!"
+    exit 0
+fi
+
+webroot=$HOME/public_html
+user=$(whoami)
 
 # Create symlink to webroot
 makehttp
-cd "$WEBROOT"
+cd "$webroot"
 
-# If user has files, move them to a new location. 
-if [ -n "$(ls -A)" ]; then
-    TS=$(date +"%Y-%m-%d_%H:%M:%S")
-    BACKUP="$HOME/webroot-$TS"
-    mkdir -p "$BACKUP"
-    echo "Webroot not empty. Moving current files to $BACKUP..." 
-    mv ./* "$BACKUP"
+# Check if user has files and let user decide what they want to do. 
+if [[ -n "$(ls -A)" ]]; then
+    echo
+    echo -e "There are currently files in webroot!\n"
+    read -rp "Do you want to back these files up? [Y/n/x] " whoknows
+
+    whoknows=${whoknows,,}
+    if [[ "$whoknows" =~ ^(yes|y|^$) ]]; then
+        ts=$(date +"%Y-%m-%d_%H:%M:%S")
+        backup="$HOME/webroot-$ts"
+        mkdir -p "$backup"
+        echo "Moving current files to $backup ..." 
+        mv ./* "$backup"
+    elif [[ "$whoknows" =~ ^(no|n) ]]; then
+        echo "Ok, say goodbye to your website."
+        rm -rf ./*
+    else
+        echo "Ok, bye!"
+        exit 0
+    fi
 fi
 
 # Get SQL password
-echo "Resetting database..."
-SQLPASS=$(echo "yes" | makemysql | tail -n 1 | grep -Po '(?<=: )([0-9a-zA-Z]){24,}$')
-if [ -z "$SQLPASS" ]; then
-    echo "  Error: Could not retrieve database password. Run makemysql to see the issue."
+echo "Resetting database password..."
+sqlpass=$(echo "yes" | makemysql | tail -n 1 | grep -Po '(?<=: )([0-9a-zA-Z]){24,}$')
+if [[ -z "$sqlpass" ]]; then
+    echo -e "\033[31mError:\033[00m Could not retrieve database password. Run makemysql to see the issue."
     exit 1
 fi
-echo "SQL set up and the password can be found in $WPCONFIG ..."
+echo "SQL set up and the password can be found in wp-config.php ..."
 
 # Install WordPress and create config file
 wp core download
-wp config create --dbname="$USER" --dbuser="$USER" --dbpass="$SQLPASS" --dbhost=mysql --dbcharset=utf8mb4 
-echo "WordPress installed successful. Go to https://www.ocf.berkeley.edu/~$USER to finish the setup process."
+wp config create --dbname="$user" --dbuser="$user" --dbpass="$sqlpass" --dbhost=mysql --dbcharset=utf8mb4 
+echo "WordPress install successful. Go to https://www.ocf.berkeley.edu/~$user to finish the setup process."


### PR DESCRIPTION
A script that an OCF user can run (ideally should be called in response to a registered user clicking a button on the OCF Website) to easily set up WordPress on their account and forgo all command line interaction. The user can finish setting up WordPress in a browser at https://www.ocf.berkeley.edu/~username