### PR TITLE
ssh-list: restrict filter for all hosts

### DIFF
--- a/staff/sys/ssh-list
+++ b/staff/sys/ssh-list
@@ -36,7 +36,7 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
     ldap_filter = {
-        'all': '(cn=*)',
+        'all': '(|(type=desktop)(type=server)(type=staffvm))',
         'desktop': '(type=desktop)',
         'server': '(|(type=server)(type=staffvm))',
     }[args.host_class]

--- a/staff/sys/ssh-list
+++ b/staff/sys/ssh-list
@@ -36,7 +36,8 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
     ldap_filter = {
-        'all': '(|(type=desktop)(type=server)(type=staffvm))',
+        'all': ('(&(cn=*)(!(type=dhcp))(!(type=ipmi))(!(type=printer))(!(type=switch))'
+                '(!(type=vip))(!(type=wifi)))'),
         'desktop': '(type=desktop)',
         'server': '(|(type=server)(type=staffvm))',
     }[args.host_class]


### PR DESCRIPTION
Let's not try to SSH into random dhcp-* hosts, or into blackhole, or into riptide-mgmt, or into lb (when we're already SSHing into whatever server lb actually happens to represent)