### PR TITLE
Get shorturls in terminal

### DIFF
--- a/net/shorturl
+++ b/net/shorturl
@@ -1,0 +1,25 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+my $PREFIX = "https://ocf.io";
+my $SHORTLINK = "https://raw.githubusercontent.com/ocf/puppet/master/modules/ocf_www/manifests/site/shorturl.pp";
+
+if ( @ARGV != 1 ) {
+    print "Usage: $0 https://rt.ocf.berkeley.edu\n";
+    print "Usage: $0 mail\n";
+    exit -1;
+}
+
+my $resp = `curl -sS -H "content-type: text/plain; charset=utf-8" $SHORTLINK`;
+$? == 0 or die "Could not retrieve short urls... Exiting!\n";
+
+foreach my $line ( split(/\n/, $resp) ) {
+    next if $line !~ /\Q$ARGV[0]\E/;
+    if ( $line =~ /'(.*)'/ ) {
+        my @awked = split /\s+/, $1;
+        next if @awked != 3;
+        my $short = substr $awked[0], 1, length($awked[0]) - 2;
+        print $PREFIX . $short . ' => ' . $awked[1] . "\n";
+    }
+}


### PR DESCRIPTION
This has come in handy for me, especially when looking at documentation online while sending emails and I want to check if there's a shorturl for what I'm looking at. You can also pass it a string, such as "mail", and all shorturls with the substring mail or shorturls that point to a url with the substring mail will be returned.

Note: It uses curl instead of a perl module (such as LWP::UserAgent) to avoid cpan nonsense. 

Also, I'm aware you guys hate perl, but it's kinda suited for this, and it's not important enough that it needs to be written in python. 