### PR TITLE
makevm: set GlobalKnownHostsFile=/dev/null

### DIFF
--- a/staff/sys/makevm
+++ b/staff/sys/makevm
@@ -169,7 +169,8 @@ def wait_drop_into_shell(ip, user, key_file):
 
     print()
     print('You should now run puppet. You will now be dropped into a shell.')
-    exec_cmd('ssh', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no',
+    exec_cmd('ssh', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'GlobalKnownHostsFile=/dev/null',
+             '-o', 'StrictHostKeyChecking=no',
              '-i', key_file, '-l', user, ip)
 
 


### PR DESCRIPTION
Since we now auto-populate /etc/ssh/ssh_known_hosts via puppet,
when rebuilding a VM, makevm sometimes prints an ugly host key
mismatch warning because the new VM's key doesn't match the cached
one in /etc/ssh/ssh_known_hosts. Fix this problem by ignoring that
file.