### PR TITLE
Add "last for desktops" script

### DIFF
--- a/sbin/last-lab
+++ b/sbin/last-lab
@@ -1,0 +1,1 @@
+../staff/lab/last-lab

--- a/staff/lab/last-lab
+++ b/staff/lab/last-lab
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+
+import ocflib.lab.stats
+from ocflib.infra.hosts import hostname_from_domain
+from tabulate import tabulate
+
+
+def make_fqdn(s):
+    """Argparse custom type that appends ".ocf.berkeley.edu" to short hostnames."""
+    if '.' not in s:
+        return s + '.ocf.berkeley.edu'
+    else:
+        return s
+
+
+def get_credentials():
+    """Return dictionary of ocfstats-ro creds, if we can read them."""
+    return json.load(open('/etc/ocfstats-ro.json', 'r'))
+
+
+def format_row(r):
+    """Given a row from the `session` table, formats it for printing."""
+    return (r['user'], hostname_from_domain(r['host']), r['start'],
+            'Still logged in' if r['end'] is None else r['end'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Print out most recent desktop login records')
+    parser.add_argument('user', nargs='?', type=str,
+                        help='Show login records for the given user')
+    parser.add_argument('-n', '--limit', type=int, default=30,
+                        help='Only show this many entries')
+    parser.add_argument('-d', '--desktop', type=make_fqdn,
+                        help='Only show logins for this desktop')
+    args = parser.parse_args()
+
+    try:
+        creds = get_credentials()
+    except FileNotFoundError:
+        print('Could not find the file for ocfstats credentials.')
+        print('Are you running this on supernova?')
+        return 1
+
+    query = ('SELECT * FROM `session` WHERE '
+             + ' AND '.join((
+                 '`user` = %s' if args.user else '1',
+                 '`host` = %s' if args.desktop else '1',
+             ))
+             + ' ORDER BY `start` DESC LIMIT %s')
+    query_args = (*filter(None, (args.user, args.desktop)), args.limit)
+
+    with ocflib.lab.stats.get_connection(**creds) as c:
+        c.execute(query, query_args)
+        print(tabulate(map(format_row, c),
+                       headers=['User', 'Desktop', 'Start', 'End']))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/staff/lab/last-lab
+++ b/staff/lab/last-lab
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import json
 import sys
 
 import ocflib.lab.stats
@@ -16,15 +15,35 @@ def make_fqdn(s):
         return s
 
 
-def get_credentials():
-    """Return dictionary of ocfstats-ro creds, if we can read them."""
-    return json.load(open('/etc/ocfstats-ro.json', 'r'))
+def build_query(args):
+    """Builds the MySQL query string with the given conditions."""
+    query = 'SELECT * FROM `session`'
+    query_args = []
+
+    query_conditions = []
+    if args.user:
+        query_conditions.append('`user` = %s')
+        query_args.append(args.user)
+    if args.desktop:
+        query_conditions.append('`host` = %s')
+        query_args.append(args.desktop)
+
+    if query_conditions:
+        query += ' WHERE ' + ' AND '.join(query_conditions)
+    query += ' ORDER BY `start` DESC LIMIT %s'
+    query_args.append(args.limit)
+
+    return (query, query_args)
 
 
 def format_row(r):
     """Given a row from the `session` table, formats it for printing."""
-    return (r['user'], hostname_from_domain(r['host']), r['start'],
-            'Still logged in' if r['end'] is None else r['end'])
+    return (
+        r['user'],
+        hostname_from_domain(r['host']),
+        r['start'],
+        'Still logged in' if r['end'] is None else r['end'],
+    )
 
 
 def main():
@@ -38,22 +57,16 @@ def main():
     args = parser.parse_args()
 
     try:
-        creds = get_credentials()
+        with open('/etc/ocfstats-ro.passwd', 'r') as fin:
+            password = fin.read().strip()
     except FileNotFoundError:
         print('Could not find the file for ocfstats credentials.')
         print('Are you running this on supernova?')
         return 1
 
-    query = ('SELECT * FROM `session` WHERE '
-             + ' AND '.join((
-                 '`user` = %s' if args.user else '1',
-                 '`host` = %s' if args.desktop else '1',
-             ))
-             + ' ORDER BY `start` DESC LIMIT %s')
-    query_args = (*filter(None, (args.user, args.desktop)), args.limit)
-
-    with ocflib.lab.stats.get_connection(**creds) as c:
-        c.execute(query, query_args)
+    with ocflib.lab.stats.get_connection(user='ocfstats-ro',
+                                         password=password) as c:
+        c.execute(*build_query(args))
         print(tabulate(map(format_row, c),
                        headers=['User', 'Desktop', 'Start', 'End']))
 

--- a/staff/lab/last-lab
+++ b/staff/lab/last-lab
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import functools
 import sys
 
 import ocflib.lab.stats
@@ -51,10 +52,19 @@ def main():
     parser.add_argument('user', nargs='?', type=str,
                         help='Show login records for the given user')
     parser.add_argument('-n', '--limit', type=int, default=30,
-                        help='Only show this many entries')
+                        help='Only show this many entries. Can also be '
+                        'specified as -<LIMIT>.')
+    # Parse limits specified in the form -<LIMIT>
+    for i in range(10):
+        parser.add_argument('-{}'.format(i), action='append_const',
+                            const=i, dest='digits', help=argparse.SUPPRESS)
     parser.add_argument('-d', '--desktop', type=make_fqdn,
                         help='Only show logins for this desktop')
     args = parser.parse_args()
+
+    if args.digits:
+        # args.digits is a list of digits. Convert that to an integer.
+        args.limit = functools.reduce(lambda x, y: 10 * x + y, args.digits)
 
     try:
         with open('/etc/ocfstats-ro.passwd', 'r') as fin:

--- a/staff/lab/last-lab
+++ b/staff/lab/last-lab
@@ -51,6 +51,10 @@ def main():
     parser = argparse.ArgumentParser(description='Print out most recent desktop login records')
     parser.add_argument('user', nargs='?', type=str,
                         help='Show login records for the given user')
+    parser.add_argument('-d', '--desktop', type=make_fqdn,
+                        help='Only show logins for this desktop')
+    parser.add_argument('-H', '--no-header', action='store_true',
+                        help='Do not print a header')
     parser.add_argument('-n', '--limit', type=int, default=30,
                         help='Only show this many entries. Can also be '
                         'specified as -<LIMIT>.')
@@ -58,8 +62,6 @@ def main():
     for i in range(10):
         parser.add_argument('-{}'.format(i), action='append_const',
                             const=i, dest='digits', help=argparse.SUPPRESS)
-    parser.add_argument('-d', '--desktop', type=make_fqdn,
-                        help='Only show logins for this desktop')
     args = parser.parse_args()
 
     if args.digits:
@@ -77,8 +79,13 @@ def main():
     with ocflib.lab.stats.get_connection(user='ocfstats-ro',
                                          password=password) as c:
         c.execute(*build_query(args))
-        print(tabulate(map(format_row, c),
-                       headers=['User', 'Desktop', 'Start', 'End']))
+        if args.no_header:
+            headers = []
+            tablefmt = 'plain'
+        else:
+            headers = ['User', 'Desktop', 'Start', 'End']
+            tablefmt = 'simple'
+        print(tabulate(map(format_row, c), headers=headers, tablefmt=tablefmt))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This command is like (a subset of) the `last` command, except it
prints out logins across desktops, retrieved from the ocfstats
database.