### PR TITLE
last-lab: implement -s, -t, -p

### DIFF
--- a/staff/lab/last-lab
+++ b/staff/lab/last-lab
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 import argparse
 import functools
-import re
 import sys
 import textwrap
 from datetime import date
 from datetime import datetime
 from datetime import time
-from datetime import timedelta
 
 import ocflib.lab.stats
 from ocflib.infra.hosts import hostname_from_domain
@@ -24,46 +22,16 @@ def make_fqdn(hostname):
 
 def parse_datetime(dtstr):
     """Argparse custom type for parsing time expresssions."""
-    # TODO: consider switching to dateparser once that becomes feasible
     FORMATS = ['%Y%m%d%H%M%S', '%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M',
                '%Y-%m-%d']
     FORMATS_TIME = ['%H:%M:%S', '%H:%M']
     WORD_EXPR = {
         'now': datetime.now(),
-        'yesterday': datetime.combine(date.today() - timedelta(days=1),
-                                      time()),
         'today': datetime.combine(date.today(), time()),
     }
 
     if dtstr in WORD_EXPR:
         return WORD_EXPR[dtstr]
-
-    if dtstr.startswith('-'):
-        match = re.match(r'[-](\d+)(\w+)', dtstr)
-        if not match:
-            raise argparse.ArgumentTypeError("invalid relative time: '{}'"
-                                             .format(dtstr))
-
-        unit = match.group(2)
-        if unit in {'y', 'year', 'years', 'yrs'}:
-            now = datetime.now()
-            return now.replace(year=now.year - int(match.group(1)))
-        else:
-            if unit in {'s', 'sec', 'second', 'seconds'}:
-                incr = timedelta(seconds=int(match.group(1)))
-            elif unit in {'m', 'min', 'minute', 'minutes'}:
-                incr = timedelta(minutes=int(match.group(1)))
-            elif unit in {'h', 'hour', 'hours', 'hr', 'hrs'}:
-                incr = timedelta(hours=int(match.group(1)))
-            elif unit in {'d', 'day', 'days'}:
-                incr = timedelta(days=int(match.group(1)))
-            elif unit in {'w', 'week', 'weeks'}:
-                incr = timedelta(days=int(match.group(1)) * 7)
-            else:
-                raise argparse.ArgumentTypeError("invalid time unit: '{}'"
-                                                 .format(unit))
-
-            return datetime.now() - incr
 
     for format in FORMATS:
         try:
@@ -137,13 +105,7 @@ def main():
                                          hh:mm:ss              (date will be set to today)
                                          hh:mm                 (date will be set to today, seconds to 00)
                                          now
-                                         yesterday             (time is set to 00:00:00)
                                          today                 (time is set to 00:00:00)
-                                         -5min
-                                         -5days
-
-                                     Due to an argparse limitation, relative times starting with a minus sign
-                                     need to be given with a =, e.g. -p=-5min.
                                      """))
     parser.add_argument('user', nargs='?', type=str,
                         help='Show login records for the given user')

--- a/staff/lab/last-lab
+++ b/staff/lab/last-lab
@@ -1,19 +1,82 @@
 #!/usr/bin/env python3
 import argparse
 import functools
+import re
 import sys
+import textwrap
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 
 import ocflib.lab.stats
 from ocflib.infra.hosts import hostname_from_domain
 from tabulate import tabulate
 
 
-def make_fqdn(s):
+def make_fqdn(hostname):
     """Argparse custom type that appends ".ocf.berkeley.edu" to short hostnames."""
-    if '.' not in s:
-        return s + '.ocf.berkeley.edu'
+    if '.' not in hostname:
+        return hostname + '.ocf.berkeley.edu'
     else:
-        return s
+        return hostname
+
+
+def parse_datetime(dtstr):
+    """Argparse custom type for parsing time expresssions."""
+    # TODO: consider switching to dateparser once that becomes feasible
+    FORMATS = ['%Y%m%d%H%M%S', '%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M',
+               '%Y-%m-%d']
+    FORMATS_TIME = ['%H:%M:%S', '%H:%M']
+    WORD_EXPR = {
+        'now': datetime.now(),
+        'yesterday': datetime.combine(date.today() - timedelta(days=1),
+                                      time()),
+        'today': datetime.combine(date.today(), time()),
+    }
+
+    if dtstr in WORD_EXPR:
+        return WORD_EXPR[dtstr]
+
+    if dtstr.startswith('-'):
+        match = re.match(r'[-](\d+)(\w+)', dtstr)
+        if not match:
+            raise argparse.ArgumentTypeError("invalid relative time: '{}'"
+                                             .format(dtstr))
+
+        unit = match.group(2)
+        if unit in {'y', 'year', 'years', 'yrs'}:
+            now = datetime.now()
+            return now.replace(year=now.year - int(match.group(1)))
+        else:
+            if unit in {'s', 'sec', 'second', 'seconds'}:
+                incr = timedelta(seconds=int(match.group(1)))
+            elif unit in {'m', 'min', 'minute', 'minutes'}:
+                incr = timedelta(minutes=int(match.group(1)))
+            elif unit in {'h', 'hour', 'hours', 'hr', 'hrs'}:
+                incr = timedelta(hours=int(match.group(1)))
+            elif unit in {'d', 'day', 'days'}:
+                incr = timedelta(days=int(match.group(1)))
+            elif unit in {'w', 'week', 'weeks'}:
+                incr = timedelta(days=int(match.group(1)) * 7)
+            else:
+                raise argparse.ArgumentTypeError("invalid time unit: '{}'"
+                                                 .format(unit))
+
+            return datetime.now() - incr
+
+    for format in FORMATS:
+        try:
+            return datetime.strptime(dtstr, format)
+        except ValueError:
+            continue
+    for format in FORMATS_TIME:
+        try:
+            return datetime.combine(date.today(),
+                                    datetime.strptime(dtstr, format).time())
+        except ValueError:
+            continue
+    raise argparse.ArgumentTypeError("date '{}' not understood".format(dtstr))
 
 
 def build_query(args):
@@ -29,8 +92,21 @@ def build_query(args):
         query_conditions.append('`host` = %s')
         query_args.append(args.desktop)
 
-    if query_conditions:
-        query += ' WHERE ' + ' AND '.join(query_conditions)
+    # Calculate the time interval satisfying all constraints.
+    # args.since and args.util have default values, so we assume they are
+    # already present.
+    since = max(args.since, args.present) if args.present else args.since
+    until = min(args.until, args.present) if args.present else args.until
+    # Sessions must end after `since` and start before `until` in order to be
+    # counted. (This is different from the observed behavior of `last`.)
+    # Sessions without an end date are treated as if they have ended infinitely
+    # far in the future.
+    query_conditions.append('(`end` IS NULL OR `end` >= %s)')
+    query_args.append(since)
+    query_conditions.append('`start` <= %s')
+    query_args.append(until)
+
+    query += ' WHERE ' + ' AND '.join(query_conditions)
     query += ' ORDER BY `start` DESC LIMIT %s'
     query_args.append(args.limit)
 
@@ -48,7 +124,27 @@ def format_row(r):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Print out most recent desktop login records')
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description='Print out most recent desktop login records',
+                                     # I ripped this epilog from util-linux
+                                     epilog=textwrap.dedent("""
+                                     TIME can be given in the following formats:
+
+                                         YYYYMMDDhhmmss
+                                         YYYY-MM-DD hh:mm:ss
+                                         YYYY-MM-DD hh:mm      (seconds will be set to 00)
+                                         YYYY-MM-DD            (time will be set to 00:00:00)
+                                         hh:mm:ss              (date will be set to today)
+                                         hh:mm                 (date will be set to today, seconds to 00)
+                                         now
+                                         yesterday             (time is set to 00:00:00)
+                                         today                 (time is set to 00:00:00)
+                                         -5min
+                                         -5days
+
+                                     Due to an argparse limitation, relative times starting with a minus sign
+                                     need to be given with a =, e.g. -p=-5min.
+                                     """))
     parser.add_argument('user', nargs='?', type=str,
                         help='Show login records for the given user')
     parser.add_argument('-d', '--desktop', type=make_fqdn,
@@ -56,12 +152,24 @@ def main():
     parser.add_argument('-H', '--no-header', action='store_true',
                         help='Do not print a header')
     parser.add_argument('-n', '--limit', type=int, default=30,
-                        help='Only show this many entries. Can also be '
-                        'specified as -<LIMIT>.')
+                        help="""Only show this many entries. Can also be
+                        specified as -<LIMIT>.""")
     # Parse limits specified in the form -<LIMIT>
     for i in range(10):
         parser.add_argument('-{}'.format(i), action='append_const',
                             const=i, dest='digits', help=argparse.SUPPRESS)
+    parser.add_argument('-p', '--present', type=parse_datetime, metavar='TIME',
+                        help="""Show the users present at the specified time.
+                        This is equivalent to using --since and --until
+                        together with the same time.""")
+    parser.add_argument('-s', '--since', type=parse_datetime, metavar='TIME',
+                        default=datetime(1000, 1, 1, 0, 0, 0),
+                        help="""Show sessions which existed on or after the
+                        specified time.""")
+    parser.add_argument('-t', '--until', type=parse_datetime, metavar='TIME',
+                        default=datetime(9999, 12, 31, 23, 59, 59),
+                        help="""Show sessions which existed on or before the
+                        specified time.""")
     args = parser.parse_args()
 
     if args.digits:


### PR DESCRIPTION
Implements the `-s`, `-t`, and `-p` options from the `last` command (although the semantics of `-s` are slightly different). This will make it easy to:

 - List which members are in the lab currently (`last-lab -p now`)
 - List which members were in the lab at 10:00 AM today (`last-lab -p 10:00`)
 - List which members have used a lab computer since midnight on February 1, 2018 (`last-lab -s 20180201`)
 - And more