### PR TITLE
Replace last python2 scripts with python3

### DIFF
--- a/acct/chsh
+++ b/acct/chsh
@@ -6,32 +6,39 @@ import sys
 from ocflib.account.manage import modify_ldap_attributes
 from ocflib.misc.validators import VALID_LOGIN_SHELLS
 
-if len(sys.argv) < 2:
-    print('Usage: chsh [shell]')
-    sys.exit(1)
 
-new_shell = sys.argv[1]
+def main(args):
+    if len(args) < 2:
+        print('Usage: chsh [shell]')
+        return 1
 
-print('Changing shell to {}...'.format(new_shell))
+    new_shell = args[1]
 
-# Check if the user has a valid kerberos ticket
-has_kerberos = subprocess.run(('/usr/bin/klist', '-t')).returncode
+    print('Changing shell to {}...'.format(new_shell))
 
-if has_kerberos != 0:
-    # The user doesn't have a valid kerberos ticket already, so obtain a new
-    # ticket (this asks for a password if they don't already have a ticket, and
-    # then uses their password to obtain a new ticket)
-    subprocess.run('/usr/bin/kinit', check=True)
+    # Check if the user has a valid kerberos ticket
+    has_kerberos = subprocess.run(('/usr/bin/klist', '-t')).returncode
 
-# modify_ldap_attributes already does loginShell validation for us to make sure
-# it's a valid shell, so we don't have to do any extra here
-try:
-    modify_ldap_attributes(getpass.getuser(), {'loginShell': new_shell})
-except ValueError as e:
-    print(e, 'valid shells are: {}'.format(list(VALID_LOGIN_SHELLS)))
-    sys.exit(1)
+    if has_kerberos != 0:
+        # The user doesn't have a valid kerberos ticket already, so obtain a new
+        # ticket (this asks for a password if they don't already have a ticket, and
+        # then uses their password to obtain a new ticket)
+        subprocess.run('/usr/bin/kinit', check=True)
 
-print(
-    'Shell successfully changed, typically it takes a while for the '
-    'changes to propagate to all our machines'
-)
+    # modify_ldap_attributes already does loginShell validation for us to make sure
+    # it's a valid shell, so we don't have to do any extra here
+    try:
+        modify_ldap_attributes(getpass.getuser(), {'loginShell': new_shell})
+    except ValueError as e:
+        print(e, 'valid shells are: {}'.format(list(VALID_LOGIN_SHELLS)))
+        return 1
+
+    print(
+        'Shell successfully changed, typically it takes a while for the '
+        'changes to propagate to all our machines'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main(sys.argv))

--- a/acct/chsh
+++ b/acct/chsh
@@ -1,42 +1,37 @@
-#!/bin/bash
+#!/usr/bin/env python3
+import getpass
+import subprocess
+import sys
 
-if [ "$#" -ne 1 ]; then
-    echo 'Usage: chsh [shell]'
-    exit 1
-fi
+from ocflib.account.manage import modify_ldap_attributes
+from ocflib.misc.validators import VALID_LOGIN_SHELLS
 
-shell_choice=$1
+if len(sys.argv) < 2:
+    print('Usage: chsh [shell]')
+    sys.exit(1)
 
-ldif_template=$(cat <<EOL
-dn: uid=$(whoami),ou=people,dc=ocf,dc=berkeley,dc=edu
-changetype: modify
-replace: loginShell
-loginShell: $shell_choice
-EOL
+new_shell = sys.argv[1]
+
+print('Changing shell to {}...'.format(new_shell))
+
+# Check if the user has a valid kerberos ticket
+has_kerberos = subprocess.run(('/usr/bin/klist', '-t')).returncode
+
+if has_kerberos != 0:
+    # The user doesn't have a valid kerberos ticket already, so obtain a new
+    # ticket (this asks for a password if they don't already have a ticket, and
+    # then uses their password to obtain a new ticket)
+    subprocess.run('/usr/bin/kinit', check=True)
+
+# modify_ldap_attributes already does loginShell validation for us to make sure
+# it's a valid shell, so we don't have to do any extra here
+try:
+    modify_ldap_attributes(getpass.getuser(), {'loginShell': new_shell})
+except ValueError as e:
+    print(e, 'valid shells are: {}'.format(list(VALID_LOGIN_SHELLS)))
+    sys.exit(1)
+
+print(
+    'Shell successfully changed, typically it takes a while for the '
+    'changes to propagate to all our machines'
 )
-
-while read -r shell; do
-    # Strip any whitespace from the shell path
-    shell="${shell## }"
-    shell="${shell%% }"
-
-    # Check that the shell choice isn't commented out and is actually a valid
-    # listed shell
-    if [ "${shell:0:1}" != "#" ] && [ "$shell_choice" = "$shell" ]; then
-        echo "Changing shell to $shell"
-        /usr/bin/klist -t || /usr/bin/kinit
-
-        # Apply the change to LDAP and silence the (rather verbose) output
-        echo "$ldif_template" | ldapmodify -Q > /dev/null
-
-        echo 'Shell successfully changed, typically it takes a while for the' \
-             'changes to propagate to all our machines'
-
-        exit 0
-    fi
-done < /etc/shells
-
-echo "The shell you chose ($shell_choice) is not valid, please chose another"\
-     'shell'
-
-exit 1

--- a/acct/chsh
+++ b/acct/chsh
@@ -1,38 +1,42 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/bin/bash
 
-import getpass
-import os
-import sys
+if [ "$#" -ne 1 ]; then
+    echo 'Usage: chsh [shell]'
+    exit 1
+fi
 
-import ldap
-import ldap.modlist as modlist
-import ldap.sasl as sasl
+shell_choice=$1
 
-if len(sys.argv) < 2:
-    print('Usage: chsh shell')
-    sys.exit()
+ldif_template=$(cat <<EOL
+dn: uid=$(whoami),ou=people,dc=ocf,dc=berkeley,dc=edu
+changetype: modify
+replace: loginShell
+loginShell: $shell_choice
+EOL
+)
 
-shell = sys.argv[1]
-etcshells = open('/etc/shells', 'r')
-line = etcshells.readline()
-while line != '':
-    validshell = line.strip()
-    if shell == validshell:
-        print('Changing shell to %s' % (validshell))
-        kinit = '/usr/bin/klist -t || /usr/bin/kinit'
-        os.system(kinit)
-        conn = ldap.initialize('ldaps://ldap.ocf.berkeley.edu:636/')
-        auth = sasl.gssapi('')
-        conn.sasl_interactive_bind_s('', auth)
-        dn = 'uid=%s,ou=people,dc=ocf,dc=berkeley,dc=edu' % (getpass.getuser())
-        old = {'loginShell': '*'}
-        new = {'loginShell': '%s' % (validshell)}
-        ldif = modlist.modifyModlist(old, new)
-        conn.modify_s(dn, ldif)
-        conn.unbind_s()
-        print('Shell successfully changed, typically it takes a while for the '
-              'changes to propagate to all our machines')
-        sys.exit()
-    line = etcshells.readline()
-print('The shell you chose is not valid, please chose another shell')
+while read -r shell; do
+    # Strip any whitespace from the shell path
+    shell="${shell## }"
+    shell="${shell%% }"
+
+    # Check that the shell choice isn't commented out and is actually a valid
+    # listed shell
+    if [ "${shell:0:1}" != "#" ] && [ "$shell_choice" = "$shell" ]; then
+        echo "Changing shell to $shell"
+        /usr/bin/klist -t || /usr/bin/kinit
+
+        # Apply the change to LDAP and silence the (rather verbose) output
+        echo "$ldif_template" | ldapmodify -Q > /dev/null
+
+        echo 'Shell successfully changed, typically it takes a while for the' \
+             'changes to propagate to all our machines'
+
+        exit 0
+    fi
+done < /etc/shells
+
+echo "The shell you chose ($shell_choice) is not valid, please chose another"\
+     'shell'
+
+exit 1

--- a/acct/chsh
+++ b/acct/chsh
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import getpass
 import subprocess
 import sys
@@ -7,12 +8,28 @@ from ocflib.account.manage import modify_ldap_attributes
 from ocflib.misc.validators import VALID_LOGIN_SHELLS
 
 
-def main(args):
-    if len(args) < 2:
-        print('Usage: chsh shell')
-        return 1
+def main():
+    parser = argparse.ArgumentParser(description='Change OCF login shell')
+    parser.add_argument(
+        '-s', '--shell',
+        help='new login shell for the user account',
+    )
+    args = parser.parse_args()
 
-    new_shell = args[1]
+    username = getpass.getuser()
+    print('Changing the login shell for {}'.format(username))
+
+    # If no shell was provided, enter interactive mode and prompt for a shell
+    if args.shell:
+        new_shell = args.shell
+    else:
+        print('Enter the new value, or press ENTER to keep your current shell')
+        new_shell = input('    Login Shell: ').strip()
+
+        # Exit if no new shell is given, as no update is needed
+        if not new_shell:
+            print('Keeping shell unchanged')
+            return 0
 
     print('Changing shell to {}...'.format(new_shell))
 
@@ -21,14 +38,13 @@ def main(args):
 
     if has_kerberos != 0:
         # The user doesn't have a valid kerberos ticket already, so obtain a new
-        # ticket (this asks for a password if they don't already have a ticket, and
-        # then uses their password to obtain a new ticket)
+        # ticket (this asks for their password)
         subprocess.run('/usr/bin/kinit', check=True)
 
     # modify_ldap_attributes already does loginShell validation for us to make sure
     # it's a valid shell, so we don't have to do any extra here
     try:
-        modify_ldap_attributes(getpass.getuser(), {'loginShell': new_shell})
+        modify_ldap_attributes(username, {'loginShell': new_shell})
     except ValueError as e:
         print(e, 'valid shells are: {}'.format(list(VALID_LOGIN_SHELLS)))
         return 1
@@ -41,4 +57,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/acct/chsh
+++ b/acct/chsh
@@ -9,7 +9,7 @@ from ocflib.misc.validators import VALID_LOGIN_SHELLS
 
 def main(args):
     if len(args) < 2:
-        print('Usage: chsh [shell]')
+        print('Usage: chsh shell')
         return 1
 
     new_shell = args[1]
@@ -41,4 +41,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    exit(main(sys.argv))
+    sys.exit(main(sys.argv))

--- a/acct/chsh
+++ b/acct/chsh
@@ -23,7 +23,7 @@ def main():
     if args.shell:
         new_shell = args.shell
     else:
-        print('Enter the new value, or press ENTER to keep your current shell')
+        print('Enter the new shell, or press ENTER to keep your current shell')
         new_shell = input('    Login Shell: ').strip()
 
         # Exit if no new shell is given, as no update is needed

--- a/acct/update-email
+++ b/acct/update-email
@@ -17,7 +17,7 @@ LDAP_MAIL_ATTR = 'mail'
 Q_UPDATE_EMAIL = 'Would you like to update your email? [yN] '
 Q_NEW_EMAIL = 'New Email Address: '
 
-AUTO_MESSAGE = '''
+AUTO_MESSAGE = """
 ================================================================================
 The Open Computing Facility requires all members to provide a valid email
 address. OCF volunteers will use this address to contact you in the event that
@@ -27,7 +27,8 @@ Your email address is kept private, and can only be viewed by OCF staff. Please
 enter an email address below that you can be reached at.
 
 For more information, see https://ocf.io/email-update
-================================================================================'''
+================================================================================
+"""
 
 
 def valid_non_ocf_email(email):
@@ -59,10 +60,7 @@ def get_email(username):
         stderr=subprocess.DEVNULL,
     ).decode('utf-8').split('\n')
 
-    mail_attr = list(filter(
-        lambda attr: attr.startswith('{}: '.format(LDAP_MAIL_ATTR)),
-        output
-    ))
+    mail_attr = [attr for attr in output if attr.startswith(LDAP_MAIL_ATTR + ': ')]
 
     if mail_attr:
         # Strip the '{LDAP_MAIL_ATTR}: ' from the beginning of the string
@@ -79,7 +77,7 @@ def set_email(username, new_email):
         sys.exit(1)
 
 
-def main(argv=None):
+def main():
     parser = argparse.ArgumentParser(description='Update OCF email')
     parser.add_argument(
         '--auto',
@@ -95,7 +93,7 @@ def main(argv=None):
     if has_kerberos != 0:
         if args.auto:
             # We can't ask for the user's password in auto mode, so we just exit
-            sys.exit(1)
+            return 1
         else:
             # The user did not already have a valid kerberos ticket, so we need
             # to obtain a new one and ask for their password
@@ -106,14 +104,14 @@ def main(argv=None):
 
     if args.auto:
         if valid_non_ocf_email(email):
-            sys.exit(0)
+            return 0
         else:
             print(AUTO_MESSAGE)
 
     print('Current Email Address: {}'.format(email or '(unset)'))
 
     if valid_non_ocf_email(email) and input(Q_UPDATE_EMAIL) not in ('y', 'yes'):
-        sys.exit(0)
+        return 0
 
     new_email = ''
     while not valid_non_ocf_email(new_email):

--- a/acct/update-email
+++ b/acct/update-email
@@ -51,6 +51,9 @@ def valid_non_ocf_email(email):
 def get_email(username):
     """Returns current email, or None."""
 
+    # Since the mail attribute is private, and we can't get the attribute's
+    # value without authenticating, we have to use ldapsearch here instead of
+    # something like ldap3.
     output = subprocess.check_output(
         ('ldapsearch', '-LLL', 'uid={}'.format(username), LDAP_MAIL_ATTR),
         stderr=subprocess.DEVNULL,
@@ -62,6 +65,7 @@ def get_email(username):
     ))
 
     if mail_attr:
+        # Strip the '{LDAP_MAIL_ATTR}: ' from the beginning of the string
         return mail_attr[0][len(LDAP_MAIL_ATTR) + 2:].strip()
 
 

--- a/acct/update-email
+++ b/acct/update-email
@@ -124,4 +124,4 @@ def main():
 
 
 if __name__ == '__main__':
-    exit(main())
+    sys.exit(main())

--- a/acct/update-email
+++ b/acct/update-email
@@ -1,31 +1,23 @@
-#!/usr/bin/env python2
-# Allows OCF users to easily change their email in LDAP
-#
-# Can be used in "auto-mode" to ask users without emails to set an email
-# address, and do nothing if an email is set. Intended to be run on login.
-from __future__ import print_function
+#!/usr/bin/env python3
+"""Allows OCF users to easily change their email in LDAP
 
+Can be used in "auto-mode" to ask users without emails to set an email
+address, and do nothing if an email is set. Intended to be run on login.
+"""
 import argparse
 import getpass
-import re
+import subprocess
 import sys
 
-import ldap
-import ldap.modlist
-import ldap.sasl
-from six.moves import input
+from ocflib.account.manage import modify_ldap_attributes
+from ocflib.misc.validators import valid_email
 
 
-MAIL_ATTR = 'mail'
-LDAP_SERVER = 'ldaps://ldap.ocf.berkeley.edu/'
-LDAP_BASE = 'ou=People,dc=OCF,dc=Berkeley,dc=EDU'
-
-EMAIL_REGEX = re.compile('^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$',
-                         re.IGNORECASE)
-
+LDAP_MAIL_ATTR = 'mail'
 Q_UPDATE_EMAIL = 'Would you like to update your email? [yN] '
 Q_NEW_EMAIL = 'New Email Address: '
-AUTO_MESSAGE = """
+
+AUTO_MESSAGE = '''
 ================================================================================
 The Open Computing Facility requires all members to provide a valid email
 address. OCF volunteers will use this address to contact you in the event that
@@ -34,111 +26,100 @@ there is a problem with your account.
 Your email address is kept private, and can only be viewed by OCF staff. Please
 enter an email address below that you can be reached at.
 
-For more information, see http://ocf.io/email-update
-================================================================================"""
+For more information, see https://ocf.io/email-update
+================================================================================'''
 
 
-def email_str(maybe_email):
-    """Returns whether maybe_email could be an email address."""
-    return EMAIL_REGEX.match(maybe_email) is not None
+def valid_non_ocf_email(email):
+    """Returns whether something is a valid email address. It must
+    represent a valid email, and not be an @ocf email address."""
 
-
-def valid_email(maybe_email):
-    """Returns whether maybe_email would be a valid email address. It must
-    represent a possible email, and not be an @ocf email address."""
-
-    if not maybe_email or not email_str(maybe_email):
+    if not email or not valid_email(email):
         return False
 
-    # @ocf emails are no longer supported.
+    # @ocf emails are no longer supported
     #
     # This can be subverted by modifying LDAP directly, but it's a reasonable
     # sanity check.
-    if maybe_email.lower().endswith('@ocf.berkeley.edu'):
+    if email.lower().endswith('@ocf.berkeley.edu'):
         print('You may not use an @ocf.berkeley.edu email address.')
         return False
 
     return True
 
 
-def get_ldap():
-    """Returns LDAP connection, or None."""
-    try:
-        auth = ldap.sasl.gssapi('')
-        conn = ldap.initialize(LDAP_SERVER)
-        conn.sasl_interactive_bind_s('', auth)
-        return conn
-    except ldap.LOCAL_ERROR:
-        return None
-
-
-def get_email(conn, dn):
+def get_email(username):
     """Returns current email, or None."""
-    results = conn.search_s(dn, ldap.SCOPE_SUBTREE, attrlist=[MAIL_ATTR])
 
-    if results:
-        attrs = results[0][1]
-        return attrs.get(MAIL_ATTR, [None])[0]
+    output = subprocess.check_output(
+        ('ldapsearch', '-LLL', 'uid={}'.format(username), LDAP_MAIL_ATTR),
+        stderr=subprocess.DEVNULL,
+    ).decode('utf-8').split('\n')
+
+    mail_attr = list(filter(
+        lambda attr: attr.startswith('{}: '.format(LDAP_MAIL_ATTR)),
+        output
+    ))
+
+    if mail_attr:
+        return mail_attr[0][len(LDAP_MAIL_ATTR) + 2:].strip()
 
 
-def set_email(conn, dn, old_email, new_email):
+def set_email(username, new_email):
     """Updates email attribute in LDAP."""
-    old = {MAIL_ATTR: '*'}
-    new = {MAIL_ATTR: new_email}
-
-    # we either need to provide old as {} or {'mail': '*'}; it will do
-    # nothing if we use the wrong one
-    #
-    # we know which one should work, but if it fails (e.g. due to a race
-    # condition), try the other one
-    def attempt_modify(modify):
-        ldif = ldap.modlist.modifyModlist(old if modify else {}, new)
-        conn.modify_s(dn, ldif)
-
-    modify = old_email is not None
 
     try:
-        attempt_modify(modify)
-    except ldap.NO_SUCH_ATTRIBUTE:
-        attempt_modify(not modify)
-
-
-def get_dn():
-    return 'uid={},{}'.format(getpass.getuser(), LDAP_BASE)
-
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Update OCF email')
-    parser.add_argument('--auto', action='store_true',
-                        help='only prompt if email is missing, suppress errors')
-    args = parser.parse_args()
-
-    conn = get_ldap()
-
-    if not conn:
-        if not args.auto:
-            print('Unable to load LDAP, try running kinit', file=sys.stderr)
+        modify_ldap_attributes(username, {LDAP_MAIL_ATTR: new_email})
+    except ValueError as e:
+        print(e)
         sys.exit(1)
 
-    dn = get_dn()
-    email = get_email(conn, dn)
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Update OCF email')
+    parser.add_argument(
+        '--auto',
+        action='store_true',
+        help='only prompt if email is missing, suppress errors',
+    )
+    args = parser.parse_args()
+
+    # Check if the user has a valid kerberos ticket. If they don't, then they
+    # will have to enter their password in order to get a new ticket
+    has_kerberos = subprocess.run(('/usr/bin/klist', '-t')).returncode
+
+    if has_kerberos != 0:
+        if args.auto:
+            # We can't ask for the user's password in auto mode, so we just exit
+            sys.exit(1)
+        else:
+            # The user did not already have a valid kerberos ticket, so we need
+            # to obtain a new one and ask for their password
+            subprocess.run('/usr/bin/kinit', check=True)
+
+    username = getpass.getuser()
+    email = get_email(username)
 
     if args.auto:
-        if valid_email(email):
+        if valid_non_ocf_email(email):
             sys.exit(0)
         else:
             print(AUTO_MESSAGE)
 
     print('Current Email Address: {}'.format(email or '(unset)'))
 
-    if valid_email(email) and input(Q_UPDATE_EMAIL) not in ('y', 'yes'):
+    if valid_non_ocf_email(email) and input(Q_UPDATE_EMAIL) not in ('y', 'yes'):
         sys.exit(0)
 
-    new_email = None
-    while not valid_email(new_email):
-        if new_email is not None:
-            print('The email you entered was invalid; please try again.')
+    new_email = ''
+    while not valid_non_ocf_email(new_email):
+        if new_email:
+            print('The email you entered was invalid; please try again.\n')
         new_email = input(Q_NEW_EMAIL).strip()
 
-    set_email(conn, dn, email, new_email)
+    set_email(username, new_email)
     print('Updated email to {}'.format(new_email))
+
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
I originally rewrote `chsh` in bash, but decided rewriting it in python was better to be able to use some ocflib functions and generally be more maintainable.

This depends on the recently merged changes made in https://github.com/ocf/ocflib/pull/148 and in https://github.com/ocf/ocflib/commit/c2c5b9c5f17f139761027d95139209e3f566ee4f.

Testing done:
- `chsh`
  - With a valid shell and a valid and invalid kerberos ticket
  - With a invalid shell and a valid and invalid kerberos ticket
- `update-email`
  - With a invalid email already in my LDAP
  - With a valid email already, but no kerberos ticket
  - In auto mode with a valid/invalid email
  - With entering an invalid email to change to (including trying to change to an OCF email, which isn't allowed)

One thing to mention is that both scripts have a kind of race condition where it can check if you have a kerberos ticket, fetch a new one for you, and then you can destroy the ticket in another terminal or something before it gets to the part that actually tries to modify LDAP, but I don't think in practice that'll be a big deal, especially not for `chsh` since you'd have to do that quite quickly to get it to happen.