### PR TITLE
migrate to ldap.berkeley.edu per recent calnet-dev email

### DIFF
--- a/acct/check
+++ b/acct/check
@@ -116,10 +116,10 @@ fi
 # check if CalNet UID number exists in LDAP
 calnetuid=$(ldapsearch -x -LLL uid="$user" calnetuid | grep -i ^calnetuid | cut -d' ' -f2)
 if [ -n "$calnetuid" ]; then
-  calnetemail=$(ldapsearch -x -LLL -H ldaps://nds.berkeley.edu -b dc=berkeley,dc=edu uid="$calnetuid" mail | grep ^mail | cut -d' ' -f2)
+  calnetemail=$(ldapsearch -x -LLL -H ldaps://ldap.berkeley.edu -b dc=berkeley,dc=edu uid="$calnetuid" mail | grep ^mail | cut -d' ' -f2)
   calnetaffiliations=
   if [ -r "$ucb_ldap_passwd_file" ]; then
-    calnetaffiliations=$(ldapsearch -x -LLL -H ldaps://nds.berkeley.edu -D uid=ocf,ou=applications,dc=berkeley,dc=edu -b dc=berkeley,dc=edu -y "$ucb_ldap_passwd_file" uid="$calnetuid" berkeleyEduAffiliations | grep ^berkeleyEduAffiliations | cut -d' ' -f2- | sed -r 's/(^|$)/\"/g' | sort | tr '\n' ' ' | sed 's/ $//g')
+    calnetaffiliations=$(ldapsearch -x -LLL -H ldaps://ldap.berkeley.edu -D uid=ocf,ou=applications,dc=berkeley,dc=edu -b dc=berkeley,dc=edu -y "$ucb_ldap_passwd_file" uid="$calnetuid" berkeleyEduAffiliations | grep ^berkeleyEduAffiliations | cut -d' ' -f2- | sed -r 's/(^|$)/\"/g' | sort | tr '\n' ' ' | sed 's/ $//g')
   fi
   echo "CalNet UID number: $calnetuid"
   if [ -n "$calnetemail" ]; then


### PR DESCRIPTION
> Dear campus developers,
> 
> The CalNet team will retire the legacy nds.berkeley.edu (nds.calnet.berkeley.edu) LDAP service on January 31, 2019.  All LDAP clients should be updated to use ldap.berkeley.edu.
>  
> On October 31, 2018 ldap.berkeley.edu was upgraded to the latest directory server software, which is a major upgrade from nds.berkeley.edu.
>  
> The majority of campus clients are already using ldap.berkeley.edu; however there are several binds still using nds.berkeley.edu.  If you are using nds.berkeley.edu, see below for steps to test and update your application.
>  
> If your service depends on LDAP, you can test the performance and functionality of the latest software using ldap-test.berkeley.edu today.  It is highly recommended that you test your applications as soon as possible and report any issues to calnet-admin@berkeley.edu.
> Attend the CalNet Tech Team meeting on November 27 for additional information or assistance.
> 
> Between now and January 31, 2019 you should update your application to use ldap.berkeley.edu.
> 
> For additional information on the SSL certificate change, and to obtain a copy of the new host certificate (if required), please see this resource for developers.
>  
> If your application experiences trouble while testing against ldap-test.berkeley.edu contact calnet-admin@berkeley.edu with a thorough description of your problem.
> 
> Best,
> 