### PR TITLE
Fix ocf-tv mute

### DIFF
--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -172,7 +172,7 @@ if __name__ == '__main__':
         description='Control the OCF television.',
     )
 
-    parser.add_argument('-H', '--host', type=str, default='tv')
+    parser.add_argument('-H', '--host', type=str, default='tv', help='set host (default tv))')
 
     command_subparser = parser.add_subparsers(dest='command')
 
@@ -209,7 +209,7 @@ if __name__ == '__main__':
         'mute',
         help='Toggle mute on the TV',
     )
-    subparser_mute.set_defaults(func=volume)
+    subparser_mute.set_defaults(func=mute)
 
     if len(sys.argv) == 1:
         args = parser.parse_args(['connect'])


### PR DESCRIPTION
Currently `ocf-tv mute` gives a python traceback when run. This commit fixes the issue.