### PR TITLE
gen-kubernetes-cert: choose a specific master to connect to

### DIFF
--- a/staff/kubernetes/gen-kubernetes-cert
+++ b/staff/kubernetes/gen-kubernetes-cert
@@ -14,7 +14,8 @@ klist -s || kinit
 
 privkey="$(openssl genrsa 2>/dev/null)"
 pubkey="$(openssl rsa -outform PEM -pubout 2>/dev/null <<< "$privkey")"
-cert="$(ssh kubernetes sudo -u kubernetes-ca certsign <<< "$pubkey")"
+kubehost="$(getent hosts kubernetes | head -1 | cut -d' ' -f1)"
+cert="$(ssh "$kubehost" sudo -u kubernetes-ca certsign <<< "$pubkey")"
 
 exec_credential='
 {


### PR DESCRIPTION
This avoid problems with ssh kerberos auth. See discussion at https://moffle.fuqu.jp/ocf/%23rebuild/20190303#L107.

Tested and working on supernova.