### PR TITLE
ocf-kubernetes-deploy: replace underscores with dashes in app name

### DIFF
--- a/staff/sys/ocf-kubernetes-deploy
+++ b/staff/sys/ocf-kubernetes-deploy
@@ -48,7 +48,8 @@ def main():
     )
     args = parser.parse_args()
 
-    namespace_name = 'app-' + args.appname
+    # Kubernetes namespaces can't have underscores
+    namespace_name = 'app-' + args.appname.replace('_', '-')
 
     # Make the namepace "app-appname"
     j = {


### PR DESCRIPTION
We need this for the `snmp_exporter` repo lol