### PR TITLE
Update signat to make it doesn't look bad

### DIFF
--- a/staff/acct/signat
+++ b/staff/acct/signat
@@ -5,6 +5,7 @@ student group.
 import argparse
 import sys
 import textwrap
+import platform
 
 import ocflib.account.search as search
 import ocflib.ucb.directory as directory
@@ -194,6 +195,15 @@ def main():
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(2)
+
+    # TODO: use UUID (/etc/machine-id) instead of hostname?
+    WORK_ON_HOSTNAME = ['supernova']
+
+    if not platform.node() in WORK_ON_HOSTNAME:
+        print("Unfortunately, this script does not work on any machine except:")
+        print(', '.join(WORK_ON_HOSTNAME))
+        print("To view the information you are requesting, ssh to any of the hostname above.")
+        sys.exit(3)
 
     args = parser.parse_args()
     if args.idtype == 'uid':


### PR DESCRIPTION
Initially it will look ugly (and makes `check` ugly because `check`
calls this - fortunately it's not function call otherwise it's gonna be more workload). This update makes it stop display ugly error on
non-supernova (or other machine in the future) machines.

It works as usual on supernova, but I'm considering if using uuid (/etc/machine-id) instead of hostname would be a better option.

Also, in the future `check` maybe rewritten in python and call functions in `signat` directly...? So do you think putting these stuff in program entrance would be a better idea...?