### PR TITLE
[OCF/util #137] easywp broken 

### DIFF
--- a/makeservices/makemysql
+++ b/makeservices/makemysql
@@ -8,4 +8,9 @@ PASS=$(sudo -u mysql /opt/share/utils/makeservices/makemysql-real | tee /dev/tty
 
 echo 'Changing WordPress database password'
 cd ~/public_html/
-wp config set DB_PASSWORD "$PASS" > /dev/null
+FILE=wp-includes/version.php
+if [ -f "$FILE" ]; then
+    wp config set DB_PASSWORD "$PASS" > /dev/null
+else
+    echo "WordPress is not installed!"
+fi


### PR DESCRIPTION
Fixes #137

Problem:
We'd produce an error after trying to update password if WordPress is not already installed

Changes: 
Added check to see if wordpress is installed before running the password update command. 