### PR TITLE
backup-user: Update NFS host warning, not on pandemic now

### DIFF
--- a/staff/acct/backup-user
+++ b/staff/acct/backup-user
@@ -1,17 +1,12 @@
 #!/bin/bash -e
 
 [ "$#" -eq 1 ]  || (echo "usage: $0 [account]" >&2; exit 1)
-[ "$(hostname)" == "supernova" ] || [ "$(hostname)" == "pandemic" ] || \
-    (echo "This isn't supernova or pandemic!" >&2; exit 1)
 [ "$(whoami)" == "root" ]  || (echo "You're not root." >&2; exit 1)
-
-[ "$(hostname)" == "supernova" ] && echo "This would be much faster on pandemic..."
+[ "$(hostname)" == "supernova" ] && echo "This would be much faster on the NFS host (homes.ocf.berkeley.edu)..."
 
 user="$1"
 passwd=$(getent passwd "$user") || (echo "Can't find that user." >&2; exit 2)
-
 tmp=$(mktemp -d --suffix="-user-backup")
-
 homedir=$(cut -d ':' -f6 <<< "$passwd")
 webdir="/services/http/users/${user:0:1}/$user"
 

--- a/staff/acct/backup-user
+++ b/staff/acct/backup-user
@@ -2,7 +2,7 @@
 
 [ "$#" -eq 1 ]  || (echo "usage: $0 [account]" >&2; exit 1)
 [ "$(whoami)" == "root" ]  || (echo "You're not root." >&2; exit 1)
-[ "$(hostname)" == "supernova" ] && echo "This would be much faster on the NFS host (homes.ocf.berkeley.edu)..."
+[ "$(hostname)" != "dataloss" ] && echo "This would be much faster on the NFS host (dataloss)..."
 
 user="$1"
 passwd=$(getent passwd "$user") || (echo "Can't find that user." >&2; exit 2)


### PR DESCRIPTION
We used to have NFS on pandemic, but that is no longer the case as of quite a few years. Let's just warn when running a user backup on `supernova` that it would be faster on the NFS host but not hardcode a hostname here.