### PR TITLE
gen-keytab: Remove incorrect TODO

### DIFF
--- a/staff/puppet/gen-keytab
+++ b/staff/puppet/gen-keytab
@@ -3,7 +3,6 @@ set -euo pipefail
 
 [ "$EUID" -eq 0 ] || { echo 'Run me as root!'; exit 1; }
 
-# TODO: Change to new share when on new puppetmaster
 PRIV_SHARE="/opt/puppet/shares/private"
 
 read -rp 'Your username: ' user


### PR DESCRIPTION
This TODO was from when we were migrating to puppetserver from the previous puppet master (I added it in https://github.com/jvperrin/utils/commit/26968446d48dcdc4381aad36f7225f53c3065683). However, since this is a symlink to the existing share, it's been fine and I don't think this TODO really makes sense to do any more since we expect this symlink to keep existing.