### PR TITLE
check: Update vhost config paths (after ocf/etc#108)

### DIFF
--- a/acct/check
+++ b/acct/check
@@ -1,19 +1,15 @@
 #!/bin/sh
 
-# Look up user for relevant account information.
+# Look up a user for relevant account information.
 
-# specify location of UCB LDAP password file
+# Locations for files containing user/vhost/login information
 ucb_ldap_passwd_file='/etc/ucbldap.passwd'
-# specify location of User_Info file
 User_Info_file='/home/s/st/staff/User_Info'
-# specify location of vhost file
-vhost_file='/home/s/st/staff/vhost/vhost.conf'
-# specify location of vhost-app file
-vhost_app_file='/home/s/st/staff/vhost/vhost-app.conf'
-# specify location of vhost-mail file
-vhost_mail_file='/home/s/st/staff/vhost/vhost-mail.conf'
-# specify location of wtmp files
+vhost_file='/etc/ocf/vhost.conf'
+vhost_app_file='/etc/ocf/vhost-app.conf'
+vhost_mail_file='/etc/ocf/vhost-mail.conf'
 wtmp_files='/var/log/wtmp /var/log/wtmp.1'
+
 # default number of logins to display from wtmp files
 login_count=5
 


### PR DESCRIPTION
This is a follow-up to ocf/etc#108 to update the vhost config paths used by `check` to use the new paths so that we can switch them to be the source of truth and so that we can remove the `~staff` vhost files at some point in the future.