### PR TITLE
check: skip over calnetuid 0

### DIFF
--- a/acct/check
+++ b/acct/check
@@ -111,7 +111,7 @@ fi
 
 # check if CalNet UID number exists in LDAP
 calnetuid=$(ldapsearch -x -LLL uid="$user" calnetuid | grep -i ^calnetuid | cut -d' ' -f2)
-if [ -n "$calnetuid" ]; then
+if [ -n "$calnetuid" ] && [ "$calnetuid" != "0" ]; then
   calnetemail=$(ldapsearch -x -LLL -H ldaps://ldap.berkeley.edu -b dc=berkeley,dc=edu uid="$calnetuid" mail | grep ^mail | cut -d' ' -f2)
   calnetaffiliations=
   if [ -r "$ucb_ldap_passwd_file" ]; then


### PR DESCRIPTION
We have a number of alumni with calnetUid = 0, which causes us to go over the lookup limit for Berkeley's ldap server