### PR TITLE
Moved get-email function to ocfutils, update update

### DIFF
--- a/acct/update-email
+++ b/acct/update-email
@@ -10,6 +10,7 @@ import subprocess
 import sys
 
 from ocflib.account.manage import modify_ldap_attributes
+from ocflib.account.utils import get_email
 from ocflib.misc.validators import valid_email
 
 
@@ -47,24 +48,6 @@ def valid_non_ocf_email(email):
         return False
 
     return True
-
-
-def get_email(username):
-    """Returns current email, or None."""
-
-    # Since the mail attribute is private, and we can't get the attribute's
-    # value without authenticating, we have to use ldapsearch here instead of
-    # something like ldap3.
-    output = subprocess.check_output(
-        ('ldapsearch', '-LLL', 'uid={}'.format(username), LDAP_MAIL_ATTR),
-        stderr=subprocess.DEVNULL,
-    ).decode('utf-8').split('\n')
-
-    mail_attr = [attr for attr in output if attr.startswith(LDAP_MAIL_ATTR + ': ')]
-
-    if mail_attr:
-        # Strip the '{LDAP_MAIL_ATTR}: ' from the beginning of the string
-        return mail_attr[0][len(LDAP_MAIL_ATTR) + 2:].strip()
 
 
 def set_email(username, new_email):


### PR DESCRIPTION
So that get-email() can be used by sorry
Note this require ocflib/beff58be1af36a699559ad64bc1ab71d9475e2b5 (some
PR https://github.com/ocf/ocflib/pull/210 ), and

fix pre-commit warnings