### PR TITLE
rewrote makemysql so that easywp might work

### DIFF
--- a/makeservices/makemysql
+++ b/makeservices/makemysql
@@ -6,6 +6,16 @@ fi
 
 PASS=$(sudo -u mysql /opt/share/utils/makeservices/makemysql-real | tee /dev/tty | tail -n 1 | grep -Po '(?<=: )([0-9a-zA-Z]){24,}$')
 
-echo 'Changing WordPress database password'
-cd ~/public_html/
-wp config set DB_PASSWORD "$PASS" > /dev/null
+# Check if wp is installed with wp-cli
+# And change password if installed with easywp
+# But change password only if installed with easywp is a wrong statement 
+if $(wp core is-installed --quiet --path=$HOME/public_html > /dev/null 2>&1) &&
+        ([ $# -ne 1 ] || ( [ $# -eq 1 ] && [ ! "$1" = '--ignore-wp' ])); then
+    wp config set DB_PASSWORD "$PASS" > /dev/null 2>&1
+fi
+# Added for backward compatibility - the last line will be
+# extracted by "tail -n 1" and the mysterious "grep"
+# will extract the password after the colon
+# So that it simulate the same behaviour as the original makemysql
+# which output the same thing as in makemysql-real
+echo "Your MySQL database password is: "$PASS


### PR DESCRIPTION
https://github.com/ocf/utils/issues/137
Problem is it used to just output `sudo -u mysql /opt/share/utils/makeservices/makemysql-real`, and after https://github.com/ocf/utils/pull/129 it's nothing, https://github.com/ocf/utils/pull/138 sometimes give a string so this will screw up, as easywp rely on some stuff extracted from `tail -n 1` that look like `Your MySQL database password is: aioeuwhgviujashfuiasb`
This one just simulate if we were running `sudo -u mysql /opt/share/utils/makeservices/makemysql-real` and output the stuff in the last line so there are probably backwards compatibility

another feature: use argument --ignore-wp to not reset in case you don't want to, and this shall remain a secret so that it is not abused

potential problems:
1. Does `(wp core is-installed --quiet --path=$HOME/public_html > /dev/null 2>&1` return true if wp exists and false otherwise
2. Change password if installed with easywp is correct but change password only if installed with easywp is a wrong statement, idk if wp-cli will also handle this
3. idk if it works