### PR TITLE
Fix tests with shellcheck on buster

### DIFF
--- a/acct/check
+++ b/acct/check
@@ -127,7 +127,7 @@ if [ -n "$calnetuid" ] && [ "$calnetuid" != "0" ]; then
 fi
 
 # check virtual hosting config
-if [ -f "$vhost_file" ] && vhost=$(grep -E "^[#[:space:]]*$user[![:space:]]" "$vhost_file"); then
+if [ -f "$vhost_file" ] && vhost=$(grep -E "^[#[:space:]]*${user}[![:space:]]" "$vhost_file"); then
   echo
   echo "Virtual hosts:"
   echo "-------------------------------------------------------------------------------"
@@ -136,7 +136,7 @@ if [ -f "$vhost_file" ] && vhost=$(grep -E "^[#[:space:]]*$user[![:space:]]" "$v
 fi
 
 # check apphosting config
-if [ -f "$vhost_app_file" ] && vhost_app=$(grep -E "^[#[:space:]]*$user[![:space:]]" "$vhost_app_file"); then
+if [ -f "$vhost_app_file" ] && vhost_app=$(grep -E "^[#[:space:]]*${user}[![:space:]]" "$vhost_app_file"); then
   echo
   echo "Virtual apphosts:"
   echo "-------------------------------------------------------------------------------"
@@ -145,7 +145,7 @@ if [ -f "$vhost_app_file" ] && vhost_app=$(grep -E "^[#[:space:]]*$user[![:space
 fi
 
 # check virtual mail config
-if [ -f "$vhost_mail_file" ] && vhost_mail=$(grep -E "^[#[:space:]]*$user[![:space:]]" "$vhost_mail_file"); then
+if [ -f "$vhost_mail_file" ] && vhost_mail=$(grep -E "^[#[:space:]]*${user}[![:space:]]" "$vhost_mail_file"); then
   echo
   echo "Virtual mail:"
   echo "-------------------------------------------------------------------------------"
@@ -210,7 +210,7 @@ if [ -n "$fingerl" ] || [ -n "$ps" ]; then
 fi
 
 # check most recent login history
-last=$( (for wtmp_file in $wtmp_files; do last -a "$user" -f "$wtmp_file"; done) | egrep -v ' begins|^$' | head -n "$login_count" | awk '{$1=""; print $0}' | sed 's/^[ ]*//g')
+last=$( (for wtmp_file in $wtmp_files; do last -a "$user" -f "$wtmp_file"; done) | grep -vE ' begins|^$' | head -n "$login_count" | awk '{$1=""; print $0}' | sed 's/^[ ]*//g')
 if [ -n "$last" ]; then
   echo
   echo "Recent login history on local machine:"

--- a/makeservices/easywp
+++ b/makeservices/easywp
@@ -16,10 +16,10 @@ if ! [[ "$(hostname)" =~ (dev-)?tsunami ]]; then
     exit 1
 fi
 
-echo -e "\033[33mWARNING: This script should generally be run on a fresh account!\033[00m"
+echo -e "\\033[33mWARNING: This script should generally be run on a fresh account!\\033[00m"
 echo -e "A user with an existing website or database will have their files
 backed up, but their database password will change and the WordPress
-install may migrate and reuse existing tables.\n"
+install may migrate and reuse existing tables.\\n"
 
 read -rp "Are you sure you want to continue? [y/N] " idunno
 idunno=${idunno,,}
@@ -38,7 +38,7 @@ cd "$webroot"
 # Check if user has files and let user decide what they want to do.
 if [[ -n "$(ls -A)" ]]; then
     echo
-    echo -e "\033[33mThere are currently files in webroot! These will be backed up.\033[00m\n"
+    echo -e "\\033[33mThere are currently files in webroot! These will be backed up.\\033[00m\\n"
     read -rp "Do you want to continue? [y/N] " whoknows
 
     whoknows=${whoknows,,}
@@ -59,7 +59,7 @@ fi
 echo "Resetting database password..."
 sqlpass=$(echo "yes" | makemysql | tail -n 1 | grep -Po '(?<=: )([0-9a-zA-Z]){24,}$')
 if [[ -z "$sqlpass" ]]; then
-    echo -e "\033[31mError:\033[00m Could not retrieve database password. Run makemysql to see the issue."
+    echo -e "\\033[31mError:\\033[00m Could not retrieve database password. Run makemysql to see the issue."
     exit 1
 fi
 echo "SQL set up and the password can be found in wp-config.php ..."

--- a/staff/acct/add-to-group
+++ b/staff/acct/add-to-group
@@ -24,9 +24,7 @@ if [ "$choice" != "y" ] && [ "$choice" != "yes" ]; then
     exit 0
 fi
 
-ldapadd <<< "$record"
-
-if [ "$?" -eq 0 ]; then
+if ldapadd <<< "$record"; then
     echo "$NEW_USER added to $LDAP_GROUP"
 else
     echo "An error occurred."

--- a/staff/acct/setup-otp
+++ b/staff/acct/setup-otp
@@ -9,7 +9,7 @@ if [[ "$(hostname)" != "lightning" && "$(hostname)" != "dev-lightning" ]]; then
 fi
 
 if [[ "$USER" != "root" ]]; then
-    echo -e "\033[1;31mYou must be root to run this.\033[0m"
+    echo -e "\\033[1;31mYou must be root to run this.\\033[0m"
     exit 1
 fi
 
@@ -21,7 +21,7 @@ fi
 username="$1"
 
 if [[ -z "$(getent passwd "$username")" ]]; then
-    echo -e "\033[1;31mUser $username does not exist.\033[0m"
+    echo -e "\\033[1;31mUser $username does not exist.\\033[0m"
     exit 1
 fi
 
@@ -32,7 +32,7 @@ read -r ykOutput
 if [[ -z "$ykOutput" ]]; then
     echo "Skipping Yubikey configuration."
 elif [[ ! "$ykOutput" =~ ^[cbdefghijklnrtuv]{44}$ ]]; then
-    echo -e "\033[1;31mThat doesn't look like a valid YubiOTP output.\033[0m Exiting."
+    echo -e "\\033[1;31mThat doesn't look like a valid YubiOTP output.\\033[0m Exiting."
     exit 1
 else
     # We submit the OTP (1) to make sure we can validate it succesfully,
@@ -40,7 +40,7 @@ else
     if curl 'https://demo.yubico.com/api/v1/simple/otp/validate' \
             -H 'Content-Type: application/json' --data '{"key":"'"$ykOutput"'"}' \
              2>/dev/null | grep -vq '"status":"success"'; then
-        echo -e "\033[1;31mFailed to verify this OTP using https://demo.yubico.com/otp/verify\033[0m"
+        echo -e "\\033[1;31mFailed to verify this OTP using https://demo.yubico.com/otp/verify\\033[0m"
         exit 1
     fi
 

--- a/staff/acct/sorry/sorry
+++ b/staff/acct/sorry/sorry
@@ -2,10 +2,10 @@
 # Script for sorrying OCF user accounts
 
 REASONPATH=/opt/share/utils/staff/acct/sorry
-LDAPSEARCH=$(which ldapsearch)
-LDAPMODIFY=$(which ldapmodify)
-KINIT=$(which kinit)
-KDESTROY=$(which kdestroy)
+LDAPSEARCH=$(command -v ldapsearch)
+LDAPMODIFY=$(command -v ldapmodify)
+KINIT=$(command -v kinit)
+KDESTROY=$(command -v kdestroy)
 #KRB5CCNAME=/root/krb5cc_sorry
 #export KRB5CCNAME
 
@@ -19,7 +19,7 @@ if [ -z "$1" ] || [ -z "$2" ]; then
     echo "Usage: $0 [user to be sorried] [sorry reason file]"
     echo
     echo "Standard Sorry Reasons:"
-    find "$REASONPATH" -maxdepth 1 -mindepth 1 -type f -printf "    %f\n"
+    find "$REASONPATH" -maxdepth 1 -mindepth 1 -type f -printf "    %f\\n"
     echo
     echo "For custom sorry reasons you can pass in your own file"
     exit 0
@@ -64,8 +64,7 @@ fi
 
 if [ -z "$SORRY_KRB5CCNAME" ]; then
     echo "You are $rootstaffer"
-    $KINIT "${rootstaffer}/admin"
-    if [ $? -ne 0 ]; then
+    if ! $KINIT "${rootstaffer}/admin"; then
         echo "kinit failed, bailing out!"
         exit 1
     fi

--- a/staff/acct/sorry/unsorry
+++ b/staff/acct/sorry/unsorry
@@ -3,9 +3,9 @@
 #Script for unsorrying OCF user accounts, adapted for ldap/kerberos
 #gfs, 3-24-08
 
-LDAPMODIFY=$(which ldapmodify)
-KINIT=$(which kinit)
-KDESTROY=$(which kdestroy)
+LDAPMODIFY=$(command -v ldapmodify)
+KINIT=$(command -v kinit)
+KDESTROY=$(command -v kdestroy)
 
 defaultshell=/bin/bash
 
@@ -62,8 +62,7 @@ fi
 
 echo "You are $rootstaffer"
 
-$KINIT "${rootstaffer}/admin"
-if [ $? -ne 0 ]; then
+if ! $KINIT "${rootstaffer}/admin"; then
     echo "kinit failed, bailing out!"
     exit 1
 fi

--- a/sys/how
+++ b/sys/how
@@ -31,7 +31,7 @@ fi
 COMMAND="$1"
 
 # find file in PATH
-file=$(which "$COMMAND" || true)
+file=$(command -v "$COMMAND" || true)
 
 # if file does not exist/is broken symlink/is not executable, command does not exist
 if [ -z "$file" ]; then
@@ -65,7 +65,7 @@ if ! ( echo "$targettype" | grep -q ^text ); then
 fi
 
 # check if pager exists
-if [ -z "$(which "$PAGER")" ]; then
+if [ -z "$(command -v "$PAGER")" ]; then
   echo "Error: Pager '$PAGER' could not be found (or not executable) in your PATH." 1>&2
   exit 1
 fi


### PR DESCRIPTION
I tested `check`, `add-to-group`, and `how`, but have not tested the other scripts apart from testing replacements to make sure they behave the same (`command -v <blah>` vs `which <blah>` for instance, or making sure that echo behaves the same with the extra backslash escaping).