### PR TITLE
Update regex for matching disk names for migrate-vm

### DIFF
--- a/staff/sys/migrate-vm
+++ b/staff/sys/migrate-vm
@@ -110,7 +110,7 @@ def verify_disks(oldpath, newpath):
     print(bold('New SHA1 (on this server): ') + copied)
 
     # Pull out the hash string since file names may not match
-    p = re.compile(r'^SHA1([a-z0-9\-/]+)= ([0-9a-f]+)$')
+    p = re.compile(r'^SHA1\(([a-z0-9\-/]+)\)= ([0-9a-f]+)$')
     if p.match(original).group(1) != p.match(copied).group(1):
         print(bold(red('Hashes do not match, something went wrong!')))
         sys.exit(1)


### PR DESCRIPTION
The output must have changed because it looks like this now:
```
Verifying disk copied...                                             
Original SHA1 (on remote server): SHA1(/dev/vg/dev-anthrax)= fccaeceb22bbb3b4939bbd0dbd74268f47f3eb56
New SHA1 (on this server): SHA1(/dev/vg/dev-anthrax)= a97db72f3c1653e538567b00431b3060f57d5e40          
Traceback (most recent call last):                                                     
  File "/opt/share/utils/sbin/migrate-vm", line 223, in <module>                            
    main()                              
  File "/opt/share/utils/sbin/migrate-vm", line 216, in main    
    verify_disks(src_lvpath, dest_lvpath)
  File "/opt/share/utils/sbin/migrate-vm", line 114, in verify_disks
    if p.match(original).group(1) != p.match(copied).group(1):  
```
This adds the brackets so it captures properly again.

Good thing is is catching actual disk errors though (yikes!)