### PR TITLE
Use card by index for ocf-tv volume control

### DIFF
--- a/staff/lab/ocf-tv
+++ b/staff/lab/ocf-tv
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import time
 
-TV_SINK = 'alsa_output.pci-0000_00_03.0.hdmi-stereo'
+TV_SINK = '0'  # card #0
 TUNNEL_NAME = 'ocf-tv-remote'
 
 


### PR DESCRIPTION
The name of the sink changes depending on what profile is selected, so use the sink by index since there's only one sink (right now).