### PR TITLE
Add mod-printer symlink

### DIFF
--- a/sbin/mod-printer
+++ b/sbin/mod-printer
@@ -1,0 +1,1 @@
+../staff/lab/mod-printer


### PR DESCRIPTION
Add symlink for `mod-printer` into `sbin`. See #174 for more details.