### PR TITLE
how: use bash

### DIFF
--- a/sys/how
+++ b/sys/how
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # how: view or edit source of a command that calls a script in $PATH
 # 2011-11-17: crudely assembled, daradib@OCF


### PR DESCRIPTION
Dash does not understand `command -v` with multiple parameters, which is causing the `how` command to fail with the output

```
/opt/share/utils/bin/how: 63: /opt/share/utils/bin/how: -en: not found
```

because it tries to execute `$(command -v greadlink readlink) -en ...` but `command` isn't outputting anything.

Furthermore, converting this script to a bash script makes it more consistent with how other OCF shell scripts work.