### PR TITLE
Solve Deprecation Warning with dns.Resolver.query()

### DIFF
--- a/acct/check-dns
+++ b/acct/check-dns
@@ -14,7 +14,7 @@ Record = namedtuple('Record', ('domain', 'type', 'value'))
 
 
 def _query(domain, record):
-    return resolver.query(domain, record, raise_on_no_answer=False)
+    return resolver.resolve(domain, record, raise_on_no_answer=False)
 
 
 def main(username):


### PR DESCRIPTION
I've tested on staff VM, and this should not cause any problem with our current version of dnspython. query() only exists for backwards compatibility with previous versions.

See: https://dnspython.readthedocs.io/en/latest/_modules/dns/resolver.html