### PR TITLE
Update makemysql user check for carp

### DIFF
--- a/makeservices/makemysql-real
+++ b/makeservices/makemysql-real
@@ -18,6 +18,7 @@ is used to parse the config file, so the format is basically the Windows
 INI format.
 """
 import os
+import pwd
 import random
 import string
 import sys
@@ -79,7 +80,7 @@ def main():
     # Without this quiet below will be local variable
     global quiet
     try:
-        username = os.environ.get('SUDO_USER')
+        username = pwd.getpwuid(os.getuid()).pw_name
 
         if not username:
             raise RuntimeError('Unable to read SUDO_USER.')

--- a/makeservices/makemysql-real
+++ b/makeservices/makemysql-real
@@ -83,7 +83,7 @@ def main():
         username = pwd.getpwuid(os.getuid()).pw_name
 
         if not username:
-            raise RuntimeError('Unable to read SUDO_USER.')
+            raise RuntimeError('Unable to read pwd.getpwuid(os.getuid()).pw_name.')
 
         # Read config file.
         mysql_host, mysql_root_pw = read_config()


### PR DESCRIPTION
SUDO_USER does not exist as an accessible environment variable on Nix for the Python os module. Replaced with pwd username check.