### PR TITLE
fix makemysql on nix

### DIFF
--- a/makeservices/makemysql
+++ b/makeservices/makemysql
@@ -30,7 +30,7 @@ done
 # makemysql-real will output the new password ONLY on the
 # last line. The --quiet will also make sure it only output the password...
 
-if ! PASS=$(sudo -u mysql /run/current-system/sw/bin/makemysql-real --quiet) ; then
+if ! PASS=$(sudo -u mysql ORIGIN_USER=$USER /run/current-system/sw/bin/makemysql-real --quiet) ; then
     echo 'makemysql-real did not exit properly.'
     echo 'Run "sudo -u mysql /run/current-system/sw/bin/makemysql-real" for a more verbose output.'
     echo 'Additionally, you may contact staff members for help. This script will stop.'

--- a/makeservices/makemysql-real
+++ b/makeservices/makemysql-real
@@ -18,7 +18,6 @@ is used to parse the config file, so the format is basically the Windows
 INI format.
 """
 import os
-import pwd
 import random
 import string
 import sys
@@ -80,10 +79,10 @@ def main():
     # Without this quiet below will be local variable
     global quiet
     try:
-        username = pwd.getpwuid(os.getuid()).pw_name
+        username = os.environ.get('ORIGIN_USER')
 
         if not username:
-            raise RuntimeError('Unable to read pwd.getpwuid(os.getuid()).pw_name.')
+            raise RuntimeError('Unable to read ORIGIN_USER.')
 
         # Read config file.
         mysql_host, mysql_root_pw = read_config()


### PR DESCRIPTION
fix SUDO_USER not existing as environment variable on nix, and incorrect pwd call that returns username 'mysql' due to sudo call in makemysql

fr ong no cap fixed this time